### PR TITLE
feat(providers): add MiniMax M3 fallback

### DIFF
--- a/manual-templates/minimax.json
+++ b/manual-templates/minimax.json
@@ -1,0 +1,44 @@
+{
+  "id": "minimax",
+  "name": "MiniMax (minimax.io)",
+  "display_name": "MiniMax (minimax.io)",
+  "models": [
+    {
+      "id": "MiniMax-M3",
+      "name": "MiniMax-M3",
+      "display_name": "MiniMax-M3",
+      "family": "minimax",
+      "attachment": true,
+      "vision": true,
+      "reasoning": {
+        "supported": true,
+        "default": true
+      },
+      "temperature": true,
+      "tool_call": true,
+      "release_date": "2026-06-01",
+      "last_updated": "2026-06-01",
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "open_weights": false,
+      "cost": {
+        "input": 0.35,
+        "output": 1.4,
+        "cache_read": 0.07,
+        "cache_write": 0.4
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 131072
+      },
+      "type": "chat"
+    }
+  ]
+}

--- a/src/templates/models-dev-template-manager.test.ts
+++ b/src/templates/models-dev-template-manager.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { ModelsDevProvider } from '../models/models-dev';
+import { mergeProviderWithTemplate } from './models-dev-template-manager';
+
+const minimaxM3Template: ModelsDevProvider = {
+  id: 'minimax',
+  name: 'MiniMax Template',
+  models: [
+    {
+      id: 'MiniMax-M3',
+      name: 'MiniMax-M3',
+      vision: true,
+      attachment: true,
+      modalities: {
+        input: ['text', 'image'],
+        output: ['text'],
+      },
+      limit: {
+        context: 1000000,
+        output: 131072,
+      },
+    },
+  ],
+};
+
+test('adds MiniMax-M3 fallback template when upstream has not published it yet', () => {
+  const upstream: ModelsDevProvider = {
+    id: 'minimax',
+    name: 'MiniMax',
+    models: [],
+  };
+
+  const merged = mergeProviderWithTemplate(upstream, minimaxM3Template);
+  const m3 = merged.models.find(model => model.id === 'MiniMax-M3');
+
+  assert.equal(m3?.limit?.context, 1000000);
+  assert.equal(m3?.vision, true);
+  assert.deepEqual(m3?.modalities?.input, ['text', 'image']);
+});
+
+test('keeps upstream MiniMax-M3 unchanged when it exists', () => {
+  const upstreamM3 = {
+    id: 'minimax-m3',
+    name: 'Upstream MiniMax M3',
+    vision: false,
+    attachment: false,
+    modalities: {
+      input: ['text'],
+      output: ['text'],
+    },
+    limit: {
+      context: 512000,
+      output: 64000,
+    },
+  };
+
+  const upstream: ModelsDevProvider = {
+    id: 'minimax',
+    name: 'MiniMax',
+    models: [upstreamM3],
+  };
+
+  const merged = mergeProviderWithTemplate(upstream, minimaxM3Template);
+
+  assert.equal(merged.models.length, 1);
+  assert.deepEqual(
+    {
+      id: merged.models[0]?.id,
+      name: merged.models[0]?.name,
+      vision: merged.models[0]?.vision,
+      attachment: merged.models[0]?.attachment,
+      modalities: merged.models[0]?.modalities,
+      limit: merged.models[0]?.limit,
+    },
+    upstreamM3,
+  );
+});

--- a/src/templates/models-dev-template-manager.ts
+++ b/src/templates/models-dev-template-manager.ts
@@ -63,6 +63,35 @@ function sanitizeProviderLike(
 
 type ModelsDevModelRecord = ModelsDevModel & Record<string, unknown>;
 
+const FALLBACK_ONLY_TEMPLATE_MODELS = new Map<string, Set<string>>([
+  ['minimax', new Set(['minimax-m3'])],
+]);
+
+function normalizeTemplateKey(value?: string): string {
+  return String(value ?? '').trim().toLowerCase();
+}
+
+function isFallbackOnlyTemplateModel(providerId: string, modelId: string): boolean {
+  return Boolean(
+    FALLBACK_ONLY_TEMPLATE_MODELS
+      .get(normalizeTemplateKey(providerId))
+      ?.has(normalizeTemplateKey(modelId)),
+  );
+}
+
+function findModelByNormalizedId(
+  models: Iterable<ModelsDevModel>,
+  modelId: string,
+): ModelsDevModel | undefined {
+  const normalizedModelId = normalizeTemplateKey(modelId);
+  for (const model of models) {
+    if (normalizeTemplateKey(model.id) === normalizedModelId) {
+      return model;
+    }
+  }
+  return undefined;
+}
+
 function moveTokenFieldsToLimit(model: ModelsDevModelRecord): void {
   const hasContextLength = model.context_length !== undefined;
   const hasMaxOutputTokens = model.max_output_tokens !== undefined;
@@ -145,7 +174,11 @@ function cloneModel(model: ModelsDevModel): ModelsDevModelRecord {
   return cloned;
 }
 
-function mergeModels(base: ModelsDevModel[] = [], override: ModelsDevModel[] = []): ModelsDevModel[] {
+function mergeModels(
+  providerId: string,
+  base: ModelsDevModel[] = [],
+  override: ModelsDevModel[] = [],
+): ModelsDevModel[] {
   if (!override.length) {
     return base.slice();
   }
@@ -163,8 +196,15 @@ function mergeModels(base: ModelsDevModel[] = [], override: ModelsDevModel[] = [
     if (!model.id) {
       continue;
     }
-    const existing = merged.get(model.id);
+    const fallbackOnly = isFallbackOnlyTemplateModel(providerId, model.id);
+    const existing =
+      merged.get(model.id) ??
+      (fallbackOnly ? findModelByNormalizedId(merged.values(), model.id) : undefined);
     if (existing) {
+      if (fallbackOnly) {
+        continue;
+      }
+
       const combined = {
         ...existing,
         ...model,
@@ -204,7 +244,7 @@ export function mergeProviderWithTemplate(
   } as ModelsDevProvider & Record<string, unknown>;
 
   merged.metadata = mergeObjects(sanitizedProvider.metadata, sanitizedTemplate.metadata);
-  merged.models = mergeModels(sanitizedProvider.models, sanitizedTemplate.models);
+  merged.models = mergeModels(merged.id, sanitizedProvider.models, sanitizedTemplate.models);
   merged.tags = mergeStringArrays(sanitizedProvider.tags, sanitizedTemplate.tags);
 
   return merged as ModelsDevProvider;


### PR DESCRIPTION
## Summary
- Add a MiniMax manual template entry for MiniMax-M3 with 1M context and image input support.
- Mark MiniMax-M3 template data as fallback-only so upstream models.dev data wins once available.
- Leave generated dist artifacts out; they can be regenerated after merge.

## Tests
- pnpm build
- pnpm exec ts-node src\templates\models-dev-template-manager.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added MiniMax-M3 model support with vision and attachment capabilities, including temperature configuration and tool-use support.

* **Tests**
  * Added test coverage for model template merging functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->