### PR TITLE
feat(providers): add DeepSeek V4 Flash vision model

### DIFF
--- a/dist/custom-provider.json
+++ b/dist/custom-provider.json
@@ -3,7 +3,7 @@
   "name": "custom provider",
   "display_name": "custom provider",
   "description": "Generated first-tier fallback catalog combining official high-signal chat, coding, reasoning, and frontier model metadata.",
-  "updated_at": "2026-08-03T00:00:00.000Z",
+  "updated_at": "2026-08-21T00:00:00.000Z",
   "doc": "docs/custom-provider.md",
   "tags": [
     "fallback",
@@ -412,6 +412,105 @@
         "source": "public-provider-conf"
       },
       "vision": false,
+      "interleaved": {
+        "field": "reasoning_content"
+      },
+      "extra_capabilities": {
+        "reasoning": {
+          "supported": true,
+          "default_enabled": true,
+          "mode": "effort",
+          "effort": "high",
+          "interleaved": true,
+          "summaries": true,
+          "visibility": "summary",
+          "continuation": [
+            "thinking_blocks"
+          ],
+          "effort_options": [
+            "low",
+            "high",
+            "max"
+          ],
+          "notes": [
+            "The DeepSeek API maps xhigh to high for V4 Flash; effort_options lists distinct model-effective levels."
+          ]
+        }
+      }
+    },
+    {
+      "id": "deepseek-v4-flash-vision-exp",
+      "name": "DeepSeek V4 Flash Vision Exp",
+      "family": "deepseek-flash",
+      "display_name": "DeepSeek V4 Flash Vision Exp",
+      "type": "chat",
+      "attachment": true,
+      "reasoning": {
+        "supported": true,
+        "default": true
+      },
+      "temperature": true,
+      "tool_call": true,
+      "structured_output": true,
+      "reasoning_options": [
+        {
+          "type": "toggle"
+        },
+        {
+          "type": "effort",
+          "values": [
+            "low",
+            "high",
+            "max"
+          ]
+        }
+      ],
+      "knowledge": "2025-05",
+      "release_date": "2026-08-21",
+      "last_updated": "2026-08-21",
+      "open_weights": true,
+      "experimental": true,
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "cost": {
+        "input": 0.14,
+        "output": 0.28,
+        "reasoning": 0.28,
+        "cache_read": 0.0028
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 384000
+      },
+      "metadata": {
+        "selection": [
+          "latest",
+          "multimodal",
+          "cost-efficient",
+          "long-context"
+        ],
+        "lifecycle": "preview",
+        "sourceProvider": "deepseek",
+        "sourceProviderName": "DeepSeek",
+        "sourceApiUrl": "https://api.deepseek.com/models",
+        "sourceDocs": [
+          "https://api-docs.deepseek.com/zh-cn/quick_start/pricing",
+          "https://api-docs.deepseek.com/zh-cn/api/create-chat-completion",
+          "https://api-docs.deepseek.com/zh-cn/guides/thinking_mode",
+          "https://api-docs.deepseek.com/news/news260424/"
+        ],
+        "sourceStatus": "seed",
+        "apiListed": false,
+        "source": "public-provider-conf"
+      },
+      "vision": true,
       "interleaved": {
         "field": "reasoning_content"
       },

--- a/dist/deepseek.json
+++ b/dist/deepseek.json
@@ -82,6 +82,88 @@
       }
     },
     {
+      "id": "deepseek-v4-flash-vision-exp",
+      "name": "DeepSeek V4 Flash Vision Exp",
+      "description": "Experimental vision-enabled DeepSeek V4 Flash model",
+      "family": "deepseek-flash",
+      "display_name": "DeepSeek V4 Flash Vision Exp",
+      "type": "chat",
+      "attachment": true,
+      "reasoning": {
+        "supported": true,
+        "default": true
+      },
+      "reasoning_options": [
+        {
+          "type": "toggle"
+        },
+        {
+          "type": "effort",
+          "values": [
+            "low",
+            "high",
+            "max"
+          ]
+        }
+      ],
+      "tool_call": true,
+      "interleaved": {
+        "field": "reasoning_content"
+      },
+      "structured_output": true,
+      "temperature": true,
+      "knowledge": "2025-05",
+      "release_date": "2026-08-21",
+      "last_updated": "2026-08-21",
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "open_weights": true,
+      "experimental": true,
+      "limit": {
+        "context": 1000000,
+        "output": 384000
+      },
+      "cost": {
+        "input": 0.14,
+        "output": 0.28,
+        "reasoning": 0.28,
+        "cache_read": 0.0028
+      },
+      "metadata": {
+        "lifecycle": "preview"
+      },
+      "vision": true,
+      "extra_capabilities": {
+        "reasoning": {
+          "supported": true,
+          "default_enabled": true,
+          "mode": "effort",
+          "effort": "high",
+          "interleaved": true,
+          "summaries": true,
+          "visibility": "summary",
+          "continuation": [
+            "thinking_blocks"
+          ],
+          "effort_options": [
+            "low",
+            "high",
+            "max"
+          ],
+          "notes": [
+            "The DeepSeek API maps xhigh to high for V4 Flash; effort_options lists distinct model-effective levels."
+          ]
+        }
+      }
+    },
+    {
       "id": "deepseek-v4-pro",
       "name": "DeepSeek V4 Pro",
       "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",

--- a/manual-templates/custom-provider-overrides.json
+++ b/manual-templates/custom-provider-overrides.json
@@ -1,6 +1,6 @@
 {
-  "updatedAt": "2026-08-03T00:00:00.000Z",
-  "maxModels": 36,
+  "updatedAt": "2026-08-21T00:00:00.000Z",
+  "maxModels": 37,
   "provider": {
     "id": "custom-provider",
     "name": "custom provider",
@@ -943,6 +943,34 @@
           "selectionRank": 1
         },
         {
+          "id": "deepseek-v4-flash-vision-exp",
+          "name": "DeepSeek V4 Flash Vision Exp",
+          "family": "deepseek-flash",
+          "contextLength": 1000000,
+          "maxTokens": 384000,
+          "vision": true,
+          "functionCall": true,
+          "reasoning": { "supported": true, "default": true },
+          "attachment": true,
+          "temperature": true,
+          "toolCall": true,
+          "structuredOutput": true,
+          "reasoningOptions": [
+            { "type": "toggle" },
+            { "type": "effort", "values": ["low", "high", "max"] }
+          ],
+          "knowledge": "2025-05",
+          "releaseDate": "2026-08-21",
+          "lastUpdated": "2026-08-21",
+          "openWeights": true,
+          "experimental": true,
+          "modalities": { "input": ["text", "image"], "output": ["text"] },
+          "cost": { "input": 0.14, "output": 0.28, "reasoning": 0.28, "cacheRead": 0.0028 },
+          "interleaved": { "field": "reasoning_content" },
+          "metadata": { "selection": ["latest", "multimodal", "cost-efficient", "long-context"], "lifecycle": "preview" },
+          "selectionRank": 2
+        },
+        {
           "id": "deepseek-v4-pro",
           "name": "DeepSeek V4 Pro",
           "family": "deepseek-thinking",
@@ -967,7 +995,7 @@
           "cost": { "input": 0.435, "output": 0.87, "reasoning": 0.87, "cacheRead": 0.003625 },
           "interleaved": { "field": "reasoning_content" },
           "metadata": { "selection": ["latest", "frontier", "long-context"], "lifecycle": "active" },
-          "selectionRank": 2
+          "selectionRank": 3
         }
       ]
     },

--- a/manual-templates/deepseek.json
+++ b/manual-templates/deepseek.json
@@ -1,0 +1,35 @@
+{
+  "id": "deepseek",
+  "name": "DeepSeek",
+  "display_name": "DeepSeek",
+  "models": [
+    {
+      "id": "deepseek-v4-flash-vision-exp",
+      "name": "DeepSeek V4 Flash Vision Exp",
+      "description": "Experimental vision-enabled DeepSeek V4 Flash model",
+      "family": "deepseek-flash",
+      "display_name": "DeepSeek V4 Flash Vision Exp",
+      "type": "chat",
+      "attachment": true,
+      "reasoning": { "supported": true, "default": true },
+      "reasoning_options": [
+        { "type": "toggle" },
+        { "type": "effort", "values": ["low", "high", "max"] }
+      ],
+      "tool_call": true,
+      "interleaved": { "field": "reasoning_content" },
+      "structured_output": true,
+      "temperature": true,
+      "knowledge": "2025-05",
+      "release_date": "2026-08-21",
+      "last_updated": "2026-08-21",
+      "modalities": { "input": ["text", "image"], "output": ["text"] },
+      "open_weights": true,
+      "experimental": true,
+      "limit": { "context": 1000000, "output": 384000 },
+      "cost": { "input": 0.14, "output": 0.28, "reasoning": 0.28, "cache_read": 0.0028 },
+      "metadata": { "lifecycle": "preview" },
+      "vision": true
+    }
+  ]
+}

--- a/src/discovery/synthesizeCustomProvider.test.ts
+++ b/src/discovery/synthesizeCustomProvider.test.ts
@@ -59,7 +59,7 @@ test('uses official doc-derived seeds when API keys are missing', async () => {
         ['Anthropic', 4],
         ['Gemini', 5],
         ['Kimi', 5],
-        ['DeepSeek', 2],
+        ['DeepSeek', 3],
         ['Zhipu', 5],
         ['MiniMax', 5],
       ],
@@ -75,6 +75,9 @@ test('creates valid normalized model cards in the provider output shape', async 
   await withoutApiKeys(async () => {
     const result = await synthesizeCustomProvider();
     const seededDeepSeekV4Flash = result.models.find(item => item.id === 'deepseek-v4-flash');
+    const seededDeepSeekV4FlashVision = result.models.find(
+      item => item.id === 'deepseek-v4-flash-vision-exp',
+    );
     const seededDeepSeekV4Pro = result.models.find(item => item.id === 'deepseek-v4-pro');
     const seededKimiK25 = result.models.find(item => item.id === 'kimi-k2.5');
     const providerInfo = createProviderInfo(
@@ -94,6 +97,9 @@ test('creates valid normalized model cards in the provider output shape', async 
     const gpt56Terra = provider.models.find(item => item.id === 'gpt-5.6-terra');
     const gpt56Luna = provider.models.find(item => item.id === 'gpt-5.6-luna');
     const deepSeekV4Flash = provider.models.find(item => item.id === 'deepseek-v4-flash');
+    const deepSeekV4FlashVision = provider.models.find(
+      item => item.id === 'deepseek-v4-flash-vision-exp',
+    );
     const deepSeekV4 = provider.models.find(item => item.id === 'deepseek-v4-pro');
     const deepSeekChat = provider.models.find(item => item.id === 'deepseek-chat');
     const claudeOpus5 = provider.models.find(item => item.id === 'claude-opus-5');
@@ -105,6 +111,12 @@ test('creates valid normalized model cards in the provider output shape', async 
 
     assert.deepEqual(
       seededDeepSeekV4Flash?.extraCapabilities?.reasoning?.effort_options,
+      ['low', 'high', 'max'],
+    );
+    assert.equal(seededDeepSeekV4FlashVision?.vision, true);
+    assert.equal(seededDeepSeekV4FlashVision?.attachment, true);
+    assert.deepEqual(
+      seededDeepSeekV4FlashVision?.extraCapabilities?.reasoning?.effort_options,
       ['low', 'high', 'max'],
     );
     assert.deepEqual(
@@ -167,6 +179,13 @@ test('creates valid normalized model cards in the provider output shape', async 
     assert.equal(deepSeekV4?.cost?.cache_read, 0.003625);
     assert.equal(deepSeekV4?.open_weights, true);
     assert.deepEqual(deepSeekV4Flash?.reasoning_options, [
+      { type: 'toggle', values: undefined },
+      { type: 'effort', values: ['low', 'high', 'max'] },
+    ]);
+    assert.equal(deepSeekV4FlashVision?.vision, true);
+    assert.equal(deepSeekV4FlashVision?.attachment, true);
+    assert.deepEqual(deepSeekV4FlashVision?.modalities?.input, ['text', 'image']);
+    assert.deepEqual(deepSeekV4FlashVision?.reasoning_options, [
       { type: 'toggle', values: undefined },
       { type: 'effort', values: ['low', 'high', 'max'] },
     ]);

--- a/src/models/extra-capabilities.test.ts
+++ b/src/models/extra-capabilities.test.ts
@@ -211,6 +211,7 @@ test('matches interleaved reasoning portraits for canonical and slash-prefixed i
   const models = [
     { id: 'deepseek-reasoner' },
     { id: 'deepseek-v4-flash' },
+    { id: 'deepseek-v4-flash-vision-exp' },
     { id: 'deepseek/deepseek-v4-pro' },
     { id: 'deepseek/deepseek-r1-0528' },
     { id: 'moonshotai/kimi-k2.5' },
@@ -229,7 +230,12 @@ test('matches interleaved reasoning portraits for canonical and slash-prefixed i
 test('applies distinct effective effort portraits to DeepSeek V4 models', () => {
   const cases = [
     {
-      ids: ['deepseek-v4-flash', 'deepseek/deepseek-v4-flash'],
+      ids: [
+        'deepseek-v4-flash',
+        'deepseek/deepseek-v4-flash',
+        'deepseek-v4-flash-vision-exp',
+        'deepseek/deepseek-v4-flash-vision-exp',
+      ],
       effortOptions: ['low', 'high', 'max'],
       notes: [
         'The DeepSeek API maps xhigh to high for V4 Flash; effort_options lists distinct model-effective levels.',

--- a/src/models/extra-capabilities.ts
+++ b/src/models/extra-capabilities.ts
@@ -436,7 +436,8 @@ const DEEPSEEK_V4_PRO_REASONING_PORTRAIT: ExtraCapabilitiesReasoning = {
 
 const REASONING_PORTRAITS: ReasoningPortraitDefinition[] = [
   {
-    matches: (_normalizedId, baseId) => baseId === 'deepseek-v4-flash',
+    matches: (_normalizedId, baseId) =>
+      baseId === 'deepseek-v4-flash' || baseId === 'deepseek-v4-flash-vision-exp',
     portrait: DEEPSEEK_V4_FLASH_REASONING_PORTRAIT,
   },
   {

--- a/src/templates/models-dev-template-manager.test.ts
+++ b/src/templates/models-dev-template-manager.test.ts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import type { ModelsDevProvider } from '../models/models-dev';
-import { mergeProviderWithTemplate } from './models-dev-template-manager';
+import {
+  mergeProviderWithTemplate,
+  ModelsDevTemplateManager,
+} from './models-dev-template-manager';
 
 test('adds template-only models to the upstream provider', () => {
   const upstream: ModelsDevProvider = {
@@ -100,4 +103,16 @@ test('merges template fields into matching upstream models', () => {
     context: 8192,
     output: 4096,
   });
+});
+
+test('patches DeepSeek with the V4 Flash vision model', async () => {
+  const templates = await new ModelsDevTemplateManager().loadAllTemplates();
+  const model = templates.get('deepseek')?.models.find(
+    item => item.id === 'deepseek-v4-flash-vision-exp',
+  );
+
+  assert.equal(model?.vision, true);
+  assert.equal(model?.attachment, true);
+  assert.deepEqual(model?.modalities?.input, ['text', 'image']);
+  assert.deepEqual(model?.limit, { context: 1000000, output: 384000 });
 });


### PR DESCRIPTION
## Summary

- add `deepseek-v4-flash-vision-exp` to the official DeepSeek provider output
- add the model to the custom provider seed catalog and generated output
- inherit DeepSeek V4 Flash reasoning, limits, pricing, and tool capabilities while enabling image input
- persist the official-provider patch through a manual DeepSeek template

## Validation

- `pnpm build`
- `pnpm exec tsc --noEmit`
- `node --test --require ts-node/register $(rg --files src -g "*.test.ts")` (44 tests passed)

## Configuration notes

- custom provider catalog capacity increases from 36 to 37 models
- `vision`, image modalities, and attachment support are enabled for the new model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the experimental DeepSeek V4 Flash Vision model.
  * Enabled vision and image inputs, attachments, reasoning controls, tool calls, and structured outputs.
  * Added pricing, token limits, preview status, and model selection metadata.
* **Updates**
  * Adjusted DeepSeek model selection ordering to include the new model.
  * Expanded capability coverage for interleaved reasoning and reasoning effort options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->