### PR TITLE
feat(custom-provider): refresh models and add StepFun and Qwen

### DIFF
--- a/dist/custom-provider.json
+++ b/dist/custom-provider.json
@@ -3,7 +3,7 @@
   "name": "custom provider",
   "display_name": "custom provider",
   "description": "Generated first-tier fallback catalog combining official high-signal chat, coding, reasoning, and frontier model metadata.",
-  "updated_at": "2026-08-21T00:00:00.000Z",
+  "updated_at": "2026-08-31T00:00:00.000Z",
   "doc": "docs/custom-provider.md",
   "tags": [
     "fallback",
@@ -382,10 +382,10 @@
         ]
       },
       "cost": {
-        "input": 0.14,
-        "output": 0.28,
-        "reasoning": 0.28,
-        "cache_read": 0.0028
+        "input": 0.44,
+        "output": 1.32,
+        "reasoning": 1.32,
+        "cache_read": 0.014
       },
       "limit": {
         "context": 1000000,
@@ -398,14 +398,19 @@
           "long-context"
         ],
         "lifecycle": "active",
+        "pricingBasis": "peak",
+        "notes": [
+          "USD per million tokens at peak hours; official off-peak prices are half these rates.",
+          "Temperature is effective only with thinking disabled; thinking mode ignores sampling parameters."
+        ],
         "sourceProvider": "deepseek",
         "sourceProviderName": "DeepSeek",
         "sourceApiUrl": "https://api.deepseek.com/models",
         "sourceDocs": [
-          "https://api-docs.deepseek.com/zh-cn/quick_start/pricing",
-          "https://api-docs.deepseek.com/zh-cn/api/create-chat-completion",
-          "https://api-docs.deepseek.com/zh-cn/guides/thinking_mode",
-          "https://api-docs.deepseek.com/news/news260424/"
+          "https://api-docs.deepseek.com/quick_start/pricing/",
+          "https://api-docs.deepseek.com/api/create-chat-completion",
+          "https://api-docs.deepseek.com/guides/thinking_mode/",
+          "https://api-docs.deepseek.com/updates/"
         ],
         "sourceStatus": "seed",
         "apiListed": false,
@@ -421,19 +426,19 @@
           "default_enabled": true,
           "mode": "effort",
           "effort": "high",
+          "effort_options": [
+            "low",
+            "high",
+            "max"
+          ],
           "interleaved": true,
           "summaries": true,
           "visibility": "summary",
           "continuation": [
             "thinking_blocks"
           ],
-          "effort_options": [
-            "low",
-            "high",
-            "max"
-          ],
           "notes": [
-            "The DeepSeek API maps xhigh to high for V4 Flash; effort_options lists distinct model-effective levels."
+            "The DeepSeek API maps medium and xhigh to high for V4 models; effort_options lists distinct model-effective levels."
           ]
         }
       }
@@ -480,10 +485,10 @@
         ]
       },
       "cost": {
-        "input": 0.14,
-        "output": 0.28,
-        "reasoning": 0.28,
-        "cache_read": 0.0028
+        "input": 0.44,
+        "output": 1.32,
+        "reasoning": 1.32,
+        "cache_read": 0.014
       },
       "limit": {
         "context": 1000000,
@@ -497,14 +502,19 @@
           "long-context"
         ],
         "lifecycle": "preview",
+        "pricingBasis": "peak",
+        "notes": [
+          "USD per million tokens at peak hours; official off-peak prices are half these rates.",
+          "Temperature is effective only with thinking disabled; thinking mode ignores sampling parameters."
+        ],
         "sourceProvider": "deepseek",
         "sourceProviderName": "DeepSeek",
         "sourceApiUrl": "https://api.deepseek.com/models",
         "sourceDocs": [
-          "https://api-docs.deepseek.com/zh-cn/quick_start/pricing",
-          "https://api-docs.deepseek.com/zh-cn/api/create-chat-completion",
-          "https://api-docs.deepseek.com/zh-cn/guides/thinking_mode",
-          "https://api-docs.deepseek.com/news/news260424/"
+          "https://api-docs.deepseek.com/quick_start/pricing/",
+          "https://api-docs.deepseek.com/api/create-chat-completion",
+          "https://api-docs.deepseek.com/guides/thinking_mode/",
+          "https://api-docs.deepseek.com/updates/"
         ],
         "sourceStatus": "seed",
         "apiListed": false,
@@ -520,19 +530,19 @@
           "default_enabled": true,
           "mode": "effort",
           "effort": "high",
+          "effort_options": [
+            "low",
+            "high",
+            "max"
+          ],
           "interleaved": true,
           "summaries": true,
           "visibility": "summary",
           "continuation": [
             "thinking_blocks"
           ],
-          "effort_options": [
-            "low",
-            "high",
-            "max"
-          ],
           "notes": [
-            "The DeepSeek API maps xhigh to high for V4 Flash; effort_options lists distinct model-effective levels."
+            "The DeepSeek API maps medium and xhigh to high for V4 models; effort_options lists distinct model-effective levels."
           ]
         }
       }
@@ -558,6 +568,7 @@
         {
           "type": "effort",
           "values": [
+            "low",
             "high",
             "max"
           ]
@@ -565,7 +576,7 @@
       ],
       "knowledge": "2025-05",
       "release_date": "2026-04-24",
-      "last_updated": "2026-04-24",
+      "last_updated": "2026-08-13",
       "open_weights": true,
       "modalities": {
         "input": [
@@ -576,10 +587,10 @@
         ]
       },
       "cost": {
-        "input": 0.435,
-        "output": 0.87,
-        "reasoning": 0.87,
-        "cache_read": 0.003625
+        "input": 1.32,
+        "output": 3.96,
+        "reasoning": 3.96,
+        "cache_read": 0.044
       },
       "limit": {
         "context": 1000000,
@@ -592,14 +603,19 @@
           "long-context"
         ],
         "lifecycle": "active",
+        "pricingBasis": "peak",
+        "notes": [
+          "USD per million tokens at peak hours; official off-peak prices are half these rates.",
+          "Temperature is effective only with thinking disabled; thinking mode ignores sampling parameters."
+        ],
         "sourceProvider": "deepseek",
         "sourceProviderName": "DeepSeek",
         "sourceApiUrl": "https://api.deepseek.com/models",
         "sourceDocs": [
-          "https://api-docs.deepseek.com/zh-cn/quick_start/pricing",
-          "https://api-docs.deepseek.com/zh-cn/api/create-chat-completion",
-          "https://api-docs.deepseek.com/zh-cn/guides/thinking_mode",
-          "https://api-docs.deepseek.com/news/news260424/"
+          "https://api-docs.deepseek.com/quick_start/pricing/",
+          "https://api-docs.deepseek.com/api/create-chat-completion",
+          "https://api-docs.deepseek.com/guides/thinking_mode/",
+          "https://api-docs.deepseek.com/updates/"
         ],
         "sourceStatus": "seed",
         "apiListed": false,
@@ -615,101 +631,19 @@
           "default_enabled": true,
           "mode": "effort",
           "effort": "high",
+          "effort_options": [
+            "low",
+            "high",
+            "max"
+          ],
           "interleaved": true,
           "summaries": true,
           "visibility": "summary",
           "continuation": [
             "thinking_blocks"
           ],
-          "effort_options": [
-            "high",
-            "max"
-          ],
           "notes": [
-            "The DeepSeek API maps low to high and xhigh to max for V4 Pro; effort_options lists distinct model-effective levels."
-          ]
-        }
-      }
-    },
-    {
-      "id": "gemini-2.5-pro",
-      "name": "Gemini 2.5 Pro",
-      "family": "gemini-pro",
-      "display_name": "Gemini 2.5 Pro",
-      "type": "chat",
-      "attachment": true,
-      "reasoning": {
-        "supported": true,
-        "default": true,
-        "budget": {
-          "min": 128,
-          "max": 32768,
-          "default": -1
-        }
-      },
-      "temperature": true,
-      "tool_call": true,
-      "structured_output": true,
-      "knowledge": "2025-01",
-      "release_date": "2025-06-17",
-      "last_updated": "2025-06-17",
-      "open_weights": false,
-      "modalities": {
-        "input": [
-          "text",
-          "image",
-          "video",
-          "audio",
-          "pdf"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "cost": {
-        "input": 1.25,
-        "output": 10,
-        "cache_read": 0.125
-      },
-      "limit": {
-        "context": 1048576,
-        "output": 65536
-      },
-      "metadata": {
-        "selection": [
-          "stable",
-          "deep-reasoning",
-          "coding"
-        ],
-        "lifecycle": "active",
-        "sourceProvider": "gemini",
-        "sourceProviderName": "Gemini",
-        "sourceApiUrl": "https://generativelanguage.googleapis.com/v1beta/models",
-        "sourceDocs": [
-          "https://ai.google.dev/gemini-api/docs/models",
-          "https://ai.google.dev/gemini-api/docs/gemini-3"
-        ],
-        "sourceStatus": "seed",
-        "apiListed": false,
-        "source": "public-provider-conf"
-      },
-      "vision": true,
-      "extra_capabilities": {
-        "reasoning": {
-          "supported": true,
-          "default_enabled": true,
-          "mode": "budget",
-          "budget": {
-            "min": 128,
-            "max": 32768,
-            "default": -1,
-            "auto": -1,
-            "unit": "tokens"
-          },
-          "summaries": true,
-          "visibility": "summary",
-          "continuation": [
-            "thought_signatures"
+            "The DeepSeek API maps medium and xhigh to high for V4 models; effort_options lists distinct model-effective levels."
           ]
         }
       }
@@ -765,7 +699,10 @@
         "sourceApiUrl": "https://generativelanguage.googleapis.com/v1beta/models",
         "sourceDocs": [
           "https://ai.google.dev/gemini-api/docs/models",
-          "https://ai.google.dev/gemini-api/docs/gemini-3"
+          "https://ai.google.dev/gemini-api/docs/gemini-3",
+          "https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash",
+          "https://ai.google.dev/gemini-api/docs/latest-model",
+          "https://ai.google.dev/gemini-api/docs/pricing"
         ],
         "sourceStatus": "seed",
         "apiListed": false,
@@ -853,7 +790,10 @@
         "sourceApiUrl": "https://generativelanguage.googleapis.com/v1beta/models",
         "sourceDocs": [
           "https://ai.google.dev/gemini-api/docs/models",
-          "https://ai.google.dev/gemini-api/docs/gemini-3"
+          "https://ai.google.dev/gemini-api/docs/gemini-3",
+          "https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash",
+          "https://ai.google.dev/gemini-api/docs/latest-model",
+          "https://ai.google.dev/gemini-api/docs/pricing"
         ],
         "sourceStatus": "seed",
         "apiListed": false,
@@ -942,7 +882,10 @@
         "sourceApiUrl": "https://generativelanguage.googleapis.com/v1beta/models",
         "sourceDocs": [
           "https://ai.google.dev/gemini-api/docs/models",
-          "https://ai.google.dev/gemini-api/docs/gemini-3"
+          "https://ai.google.dev/gemini-api/docs/gemini-3",
+          "https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash",
+          "https://ai.google.dev/gemini-api/docs/latest-model",
+          "https://ai.google.dev/gemini-api/docs/pricing"
         ],
         "sourceStatus": "seed",
         "apiListed": false,
@@ -1008,7 +951,6 @@
       },
       "metadata": {
         "selection": [
-          "latest",
           "fast",
           "multimodal",
           "reasoning"
@@ -1019,7 +961,10 @@
         "sourceApiUrl": "https://generativelanguage.googleapis.com/v1beta/models",
         "sourceDocs": [
           "https://ai.google.dev/gemini-api/docs/models",
-          "https://ai.google.dev/gemini-api/docs/gemini-3"
+          "https://ai.google.dev/gemini-api/docs/gemini-3",
+          "https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash",
+          "https://ai.google.dev/gemini-api/docs/latest-model",
+          "https://ai.google.dev/gemini-api/docs/pricing"
         ],
         "sourceStatus": "seed",
         "apiListed": false,
@@ -1047,12 +992,12 @@
       }
     },
     {
-      "id": "glm-4.7",
-      "name": "GLM-4.7",
-      "family": "glm",
-      "display_name": "GLM-4.7",
+      "id": "gemini-3.7-flash",
+      "name": "Gemini 3.7 Flash",
+      "family": "gemini-flash",
+      "display_name": "Gemini 3.7 Flash",
       "type": "chat",
-      "attachment": false,
+      "attachment": true,
       "reasoning": {
         "supported": true,
         "default": true
@@ -1060,209 +1005,83 @@
       "temperature": true,
       "tool_call": true,
       "structured_output": true,
-      "knowledge": "2025-04",
-      "release_date": "2025-12-22",
-      "last_updated": "2025-12-22",
-      "open_weights": true,
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "cost": {
-        "input": 0.6,
-        "output": 2.2,
-        "cache_read": 0.11,
-        "cache_write": 0
-      },
-      "limit": {
-        "context": 204800,
-        "output": 131072
-      },
-      "metadata": {
-        "selection": [
-          "open-weight",
-          "coding",
-          "reasoning"
-        ],
-        "lifecycle": "active",
-        "sourceProvider": "zhipu",
-        "sourceProviderName": "Zhipu",
-        "sourceDocs": [
-          "https://docs.z.ai/guides/llm/glm-5.2",
-          "https://docs.z.ai/guides/llm/glm-5.1",
-          "https://docs.z.ai/guides/overview/pricing",
-          "https://docs.bigmodel.cn/cn/guide/start/model-overview",
-          "https://docs.bigmodel.cn/cn/guide/start/migrate-to-glm-new",
-          "https://docs.bigmodel.cn/cn/guide/capabilities/thinking"
-        ],
-        "sourceStatus": "seed",
-        "apiListed": false,
-        "source": "public-provider-conf"
-      },
-      "vision": false,
-      "interleaved": {
-        "field": "reasoning_content"
-      },
-      "extra_capabilities": {
-        "reasoning": {
-          "supported": true,
-          "interleaved": true,
-          "summaries": true,
-          "visibility": "summary",
-          "continuation": [
-            "thinking_blocks"
-          ],
-          "default_enabled": true
+      "reasoning_options": [
+        {
+          "type": "effort",
+          "values": [
+            "low",
+            "medium",
+            "high"
+          ]
         }
-      }
-    },
-    {
-      "id": "glm-5",
-      "name": "GLM-5",
-      "family": "glm",
-      "display_name": "GLM-5",
-      "type": "chat",
-      "attachment": false,
-      "reasoning": {
-        "supported": true,
-        "default": true
-      },
-      "temperature": true,
-      "tool_call": true,
-      "structured_output": true,
-      "release_date": "2026-02-11",
-      "last_updated": "2026-02-11",
-      "open_weights": true,
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "cost": {
-        "input": 1,
-        "output": 3.2,
-        "cache_read": 0.2,
-        "cache_write": 0
-      },
-      "limit": {
-        "context": 204800,
-        "output": 131072
-      },
-      "metadata": {
-        "selection": [
-          "coding",
-          "agentic",
-          "reasoning"
-        ],
-        "lifecycle": "active",
-        "sourceProvider": "zhipu",
-        "sourceProviderName": "Zhipu",
-        "sourceDocs": [
-          "https://docs.z.ai/guides/llm/glm-5.2",
-          "https://docs.z.ai/guides/llm/glm-5.1",
-          "https://docs.z.ai/guides/overview/pricing",
-          "https://docs.bigmodel.cn/cn/guide/start/model-overview",
-          "https://docs.bigmodel.cn/cn/guide/start/migrate-to-glm-new",
-          "https://docs.bigmodel.cn/cn/guide/capabilities/thinking"
-        ],
-        "sourceStatus": "seed",
-        "apiListed": false,
-        "source": "public-provider-conf"
-      },
-      "vision": false,
-      "interleaved": {
-        "field": "reasoning_content"
-      },
-      "extra_capabilities": {
-        "reasoning": {
-          "supported": true,
-          "interleaved": true,
-          "summaries": true,
-          "visibility": "summary",
-          "continuation": [
-            "thinking_blocks"
-          ],
-          "default_enabled": true
-        }
-      }
-    },
-    {
-      "id": "glm-5.1",
-      "name": "GLM-5.1",
-      "family": "glm",
-      "display_name": "GLM-5.1",
-      "type": "chat",
-      "attachment": false,
-      "reasoning": {
-        "supported": true,
-        "default": true
-      },
-      "temperature": true,
-      "tool_call": true,
-      "structured_output": true,
-      "release_date": "2026-03-27",
-      "last_updated": "2026-03-27",
+      ],
+      "last_updated": "2026-08-31",
       "open_weights": false,
       "modalities": {
         "input": [
-          "text"
+          "text",
+          "image",
+          "video",
+          "audio",
+          "pdf"
         ],
         "output": [
           "text"
         ]
       },
       "cost": {
-        "input": 1.4,
-        "output": 4.4,
-        "cache_read": 0.26,
-        "cache_write": 0
+        "input": 0.75,
+        "output": 3.75,
+        "cache_read": 0.075
       },
       "limit": {
-        "context": 200000,
-        "output": 131072
+        "context": 1048576,
+        "output": 65536
       },
       "metadata": {
         "selection": [
           "latest",
-          "coding",
-          "long-horizon"
+          "fast",
+          "multimodal",
+          "reasoning"
         ],
         "lifecycle": "active",
-        "sourceProvider": "zhipu",
-        "sourceProviderName": "Zhipu",
+        "pricingBasis": "standard-introductory",
+        "pricingValidUntil": "2026-12-31",
+        "sourceProvider": "gemini",
+        "sourceProviderName": "Gemini",
+        "sourceApiUrl": "https://generativelanguage.googleapis.com/v1beta/models",
         "sourceDocs": [
-          "https://docs.z.ai/guides/llm/glm-5.2",
-          "https://docs.z.ai/guides/llm/glm-5.1",
-          "https://docs.z.ai/guides/overview/pricing",
-          "https://docs.bigmodel.cn/cn/guide/start/model-overview",
-          "https://docs.bigmodel.cn/cn/guide/start/migrate-to-glm-new",
-          "https://docs.bigmodel.cn/cn/guide/capabilities/thinking"
+          "https://ai.google.dev/gemini-api/docs/models",
+          "https://ai.google.dev/gemini-api/docs/gemini-3",
+          "https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash",
+          "https://ai.google.dev/gemini-api/docs/latest-model",
+          "https://ai.google.dev/gemini-api/docs/pricing"
         ],
         "sourceStatus": "seed",
         "apiListed": false,
         "source": "public-provider-conf"
       },
-      "vision": false,
-      "interleaved": {
-        "field": "reasoning_content"
-      },
+      "vision": true,
       "extra_capabilities": {
         "reasoning": {
           "supported": true,
-          "continuation": [
-            "thinking_blocks"
+          "default_enabled": true,
+          "mode": "level",
+          "level": "medium",
+          "level_options": [
+            "low",
+            "medium",
+            "high"
           ],
-          "interleaved": true,
           "summaries": true,
           "visibility": "summary",
-          "default_enabled": true
+          "continuation": [
+            "thought_signatures"
+          ],
+          "notes": [
+            "The thinkingLevel parameter does not accept minimal."
+          ]
         }
       }
     },
@@ -1280,6 +1099,18 @@
       "temperature": true,
       "tool_call": true,
       "structured_output": true,
+      "reasoning_options": [
+        {
+          "type": "toggle"
+        },
+        {
+          "type": "effort",
+          "values": [
+            "high",
+            "max"
+          ]
+        }
+      ],
       "release_date": "2026-06-13",
       "last_updated": "2026-06-13",
       "open_weights": true,
@@ -1303,21 +1134,19 @@
       },
       "metadata": {
         "selection": [
-          "latest",
           "coding",
           "long-context",
-          "reasoning"
+          "optional-thinking"
         ],
         "lifecycle": "active",
         "sourceProvider": "zhipu",
         "sourceProviderName": "Zhipu",
         "sourceDocs": [
+          "https://docs.z.ai/guides/llm/glm-5.3",
+          "https://docs.z.ai/guides/vlm/glm-5.3-flash",
           "https://docs.z.ai/guides/llm/glm-5.2",
-          "https://docs.z.ai/guides/llm/glm-5.1",
-          "https://docs.z.ai/guides/overview/pricing",
-          "https://docs.bigmodel.cn/cn/guide/start/model-overview",
-          "https://docs.bigmodel.cn/cn/guide/start/migrate-to-glm-new",
-          "https://docs.bigmodel.cn/cn/guide/capabilities/thinking"
+          "https://docs.z.ai/guides/capabilities/thinking-mode",
+          "https://docs.z.ai/guides/overview/pricing"
         ],
         "sourceStatus": "seed",
         "apiListed": false,
@@ -1347,10 +1176,101 @@
       }
     },
     {
-      "id": "glm-5v-turbo",
-      "name": "GLM-5V-Turbo",
+      "id": "glm-5.3",
+      "name": "GLM-5.3",
       "family": "glm",
-      "display_name": "GLM-5V-Turbo",
+      "display_name": "GLM-5.3",
+      "type": "chat",
+      "attachment": false,
+      "reasoning": {
+        "supported": true,
+        "default": true
+      },
+      "temperature": true,
+      "tool_call": true,
+      "structured_output": true,
+      "reasoning_options": [
+        {
+          "type": "effort",
+          "values": [
+            "low",
+            "high",
+            "max"
+          ]
+        }
+      ],
+      "last_updated": "2026-08-31",
+      "open_weights": true,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "cost": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_read": 0.26
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 131072
+      },
+      "metadata": {
+        "selection": [
+          "latest",
+          "coding",
+          "long-context",
+          "reasoning"
+        ],
+        "lifecycle": "active",
+        "sourceProvider": "zhipu",
+        "sourceProviderName": "Zhipu",
+        "sourceDocs": [
+          "https://docs.z.ai/guides/llm/glm-5.3",
+          "https://docs.z.ai/guides/vlm/glm-5.3-flash",
+          "https://docs.z.ai/guides/llm/glm-5.2",
+          "https://docs.z.ai/guides/capabilities/thinking-mode",
+          "https://docs.z.ai/guides/overview/pricing"
+        ],
+        "sourceStatus": "seed",
+        "apiListed": false,
+        "source": "public-provider-conf"
+      },
+      "vision": false,
+      "interleaved": {
+        "field": "reasoning_content"
+      },
+      "extra_capabilities": {
+        "reasoning": {
+          "supported": true,
+          "effort_options": [
+            "low",
+            "high",
+            "max"
+          ],
+          "continuation": [
+            "thinking_blocks"
+          ],
+          "notes": [
+            "Thinking cannot be disabled; reasoning_effort defaults to max. Set thinking.clear_thinking to false to preserve reasoning across turns."
+          ],
+          "interleaved": true,
+          "summaries": true,
+          "visibility": "summary",
+          "default_enabled": true,
+          "mode": "effort",
+          "effort": "max"
+        }
+      }
+    },
+    {
+      "id": "glm-5.3-flash",
+      "name": "GLM-5.3 Flash",
+      "family": "glm",
+      "display_name": "GLM-5.3 Flash",
       "type": "chat",
       "attachment": true,
       "reasoning": {
@@ -1360,46 +1280,56 @@
       "temperature": true,
       "tool_call": true,
       "structured_output": true,
-      "release_date": "2026-04-01",
-      "last_updated": "2026-04-01",
-      "open_weights": false,
+      "reasoning_options": [
+        {
+          "type": "effort",
+          "values": [
+            "low",
+            "high",
+            "max"
+          ]
+        }
+      ],
+      "last_updated": "2026-08-31",
+      "open_weights": true,
       "modalities": {
         "input": [
           "text",
           "image",
           "video",
-          "pdf"
+          "file"
         ],
         "output": [
           "text"
         ]
       },
       "cost": {
-        "input": 5,
-        "output": 22,
-        "cache_read": 1.2,
-        "cache_write": 0
+        "input": 0.075,
+        "output": 0.25,
+        "cache_read": 0.015
       },
       "limit": {
-        "context": 200000,
+        "context": 1000000,
         "output": 131072
       },
       "metadata": {
         "selection": [
-          "vision",
+          "latest",
+          "multimodal",
           "coding",
-          "reasoning"
+          "cost-efficient"
         ],
         "lifecycle": "active",
+        "pricingBasis": "promotional",
+        "pricingValidUntil": "2026-09-10T00:00:00+08:00",
         "sourceProvider": "zhipu",
         "sourceProviderName": "Zhipu",
         "sourceDocs": [
+          "https://docs.z.ai/guides/llm/glm-5.3",
+          "https://docs.z.ai/guides/vlm/glm-5.3-flash",
           "https://docs.z.ai/guides/llm/glm-5.2",
-          "https://docs.z.ai/guides/llm/glm-5.1",
-          "https://docs.z.ai/guides/overview/pricing",
-          "https://docs.bigmodel.cn/cn/guide/start/model-overview",
-          "https://docs.bigmodel.cn/cn/guide/start/migrate-to-glm-new",
-          "https://docs.bigmodel.cn/cn/guide/capabilities/thinking"
+          "https://docs.z.ai/guides/capabilities/thinking-mode",
+          "https://docs.z.ai/guides/overview/pricing"
         ],
         "sourceStatus": "seed",
         "apiListed": false,
@@ -1412,429 +1342,23 @@
       "extra_capabilities": {
         "reasoning": {
           "supported": true,
-          "interleaved": true,
-          "summaries": true,
-          "visibility": "summary",
+          "effort_options": [
+            "low",
+            "high",
+            "max"
+          ],
           "continuation": [
             "thinking_blocks"
           ],
-          "default_enabled": true
-        }
-      }
-    },
-    {
-      "id": "gpt-5.3-codex",
-      "name": "GPT-5.3 Codex",
-      "family": "gpt-codex",
-      "display_name": "GPT-5.3 Codex",
-      "type": "chat",
-      "attachment": true,
-      "reasoning": {
-        "supported": true,
-        "default": true
-      },
-      "temperature": false,
-      "tool_call": true,
-      "structured_output": true,
-      "knowledge": "2025-08-31",
-      "release_date": "2026-02-05",
-      "last_updated": "2026-02-05",
-      "open_weights": false,
-      "modalities": {
-        "input": [
-          "text",
-          "image",
-          "pdf"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "cost": {
-        "input": 1.75,
-        "output": 14,
-        "cache_read": 0.175
-      },
-      "limit": {
-        "context": 400000,
-        "output": 128000
-      },
-      "metadata": {
-        "selection": [
-          "coding",
-          "agentic",
-          "reasoning"
-        ],
-        "lifecycle": "active",
-        "sourceProvider": "openai",
-        "sourceProviderName": "OpenAI",
-        "sourceApiUrl": "https://api.openai.com/v1/models",
-        "sourceDocs": [
-          "https://developers.openai.com/api/docs/models",
-          "https://developers.openai.com/api/docs/guides/latest-model",
-          "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
-          "https://developers.openai.com/api/docs/models/gpt-5.6-terra",
-          "https://developers.openai.com/api/docs/models/gpt-5.6-luna",
-          "https://developers.openai.com/api/docs/models/gpt-5.4",
-          "https://developers.openai.com/api/docs/models/gpt-5.3-codex"
-        ],
-        "sourceStatus": "seed",
-        "apiListed": false,
-        "source": "public-provider-conf"
-      },
-      "vision": true,
-      "extra_capabilities": {
-        "reasoning": {
-          "supported": true,
+          "notes": [
+            "Thinking cannot be disabled; reasoning_effort defaults to max. Set thinking.clear_thinking to false to preserve reasoning across turns."
+          ],
+          "interleaved": true,
+          "summaries": true,
+          "visibility": "summary",
           "default_enabled": true,
           "mode": "effort",
-          "effort": "medium",
-          "effort_options": [
-            "low",
-            "medium",
-            "high",
-            "xhigh"
-          ],
-          "verbosity": "medium",
-          "verbosity_options": [
-            "low",
-            "medium",
-            "high"
-          ],
-          "visibility": "hidden"
-        }
-      }
-    },
-    {
-      "id": "gpt-5.4",
-      "name": "GPT-5.4",
-      "family": "gpt",
-      "display_name": "GPT-5.4",
-      "type": "chat",
-      "attachment": true,
-      "reasoning": {
-        "supported": true,
-        "default": false
-      },
-      "temperature": false,
-      "tool_call": true,
-      "structured_output": true,
-      "knowledge": "2025-08-31",
-      "release_date": "2026-03-05",
-      "last_updated": "2026-03-05",
-      "open_weights": false,
-      "modalities": {
-        "input": [
-          "text",
-          "image",
-          "pdf"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "cost": {
-        "input": 2.5,
-        "output": 15,
-        "cache_read": 0.25
-      },
-      "limit": {
-        "context": 1050000,
-        "output": 128000
-      },
-      "metadata": {
-        "selection": [
-          "frontier",
-          "coding",
-          "reasoning"
-        ],
-        "lifecycle": "active",
-        "sourceProvider": "openai",
-        "sourceProviderName": "OpenAI",
-        "sourceApiUrl": "https://api.openai.com/v1/models",
-        "sourceDocs": [
-          "https://developers.openai.com/api/docs/models",
-          "https://developers.openai.com/api/docs/guides/latest-model",
-          "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
-          "https://developers.openai.com/api/docs/models/gpt-5.6-terra",
-          "https://developers.openai.com/api/docs/models/gpt-5.6-luna",
-          "https://developers.openai.com/api/docs/models/gpt-5.4",
-          "https://developers.openai.com/api/docs/models/gpt-5.3-codex"
-        ],
-        "sourceStatus": "seed",
-        "apiListed": false,
-        "source": "public-provider-conf"
-      },
-      "vision": true,
-      "extra_capabilities": {
-        "reasoning": {
-          "supported": true,
-          "default_enabled": false,
-          "mode": "effort",
-          "effort": "none",
-          "effort_options": [
-            "none",
-            "low",
-            "medium",
-            "high",
-            "xhigh"
-          ],
-          "verbosity": "medium",
-          "verbosity_options": [
-            "low",
-            "medium",
-            "high"
-          ],
-          "visibility": "hidden"
-        }
-      }
-    },
-    {
-      "id": "gpt-5.4-mini",
-      "name": "GPT-5.4 Mini",
-      "family": "gpt",
-      "display_name": "GPT-5.4 Mini",
-      "type": "chat",
-      "attachment": true,
-      "reasoning": {
-        "supported": true,
-        "default": false
-      },
-      "temperature": false,
-      "tool_call": true,
-      "structured_output": true,
-      "knowledge": "2025-08-31",
-      "release_date": "2026-03-17",
-      "last_updated": "2026-03-17",
-      "open_weights": false,
-      "modalities": {
-        "input": [
-          "text",
-          "image",
-          "pdf"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "cost": {
-        "input": 0.75,
-        "output": 4.5,
-        "cache_read": 0.075
-      },
-      "limit": {
-        "context": 400000,
-        "output": 128000
-      },
-      "metadata": {
-        "selection": [
-          "fast",
-          "coding",
-          "cost-efficient"
-        ],
-        "lifecycle": "active",
-        "sourceProvider": "openai",
-        "sourceProviderName": "OpenAI",
-        "sourceApiUrl": "https://api.openai.com/v1/models",
-        "sourceDocs": [
-          "https://developers.openai.com/api/docs/models",
-          "https://developers.openai.com/api/docs/guides/latest-model",
-          "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
-          "https://developers.openai.com/api/docs/models/gpt-5.6-terra",
-          "https://developers.openai.com/api/docs/models/gpt-5.6-luna",
-          "https://developers.openai.com/api/docs/models/gpt-5.4",
-          "https://developers.openai.com/api/docs/models/gpt-5.3-codex"
-        ],
-        "sourceStatus": "seed",
-        "apiListed": false,
-        "source": "public-provider-conf"
-      },
-      "vision": true,
-      "extra_capabilities": {
-        "reasoning": {
-          "supported": true,
-          "default_enabled": false,
-          "mode": "effort",
-          "effort": "none",
-          "effort_options": [
-            "none",
-            "low",
-            "medium",
-            "high",
-            "xhigh"
-          ],
-          "verbosity": "medium",
-          "verbosity_options": [
-            "low",
-            "medium",
-            "high"
-          ],
-          "visibility": "hidden"
-        }
-      }
-    },
-    {
-      "id": "gpt-5.4-nano",
-      "name": "GPT-5.4 Nano",
-      "family": "gpt",
-      "display_name": "GPT-5.4 Nano",
-      "type": "chat",
-      "attachment": true,
-      "reasoning": {
-        "supported": true,
-        "default": false
-      },
-      "temperature": false,
-      "tool_call": true,
-      "structured_output": true,
-      "knowledge": "2025-08-31",
-      "release_date": "2026-03-17",
-      "last_updated": "2026-03-17",
-      "open_weights": false,
-      "modalities": {
-        "input": [
-          "text",
-          "image",
-          "pdf"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "cost": {
-        "input": 0.2,
-        "output": 1.25,
-        "cache_read": 0.02
-      },
-      "limit": {
-        "context": 400000,
-        "output": 128000
-      },
-      "metadata": {
-        "selection": [
-          "small",
-          "cost-efficient",
-          "fallback"
-        ],
-        "lifecycle": "active",
-        "sourceProvider": "openai",
-        "sourceProviderName": "OpenAI",
-        "sourceApiUrl": "https://api.openai.com/v1/models",
-        "sourceDocs": [
-          "https://developers.openai.com/api/docs/models",
-          "https://developers.openai.com/api/docs/guides/latest-model",
-          "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
-          "https://developers.openai.com/api/docs/models/gpt-5.6-terra",
-          "https://developers.openai.com/api/docs/models/gpt-5.6-luna",
-          "https://developers.openai.com/api/docs/models/gpt-5.4",
-          "https://developers.openai.com/api/docs/models/gpt-5.3-codex"
-        ],
-        "sourceStatus": "seed",
-        "apiListed": false,
-        "source": "public-provider-conf"
-      },
-      "vision": true,
-      "extra_capabilities": {
-        "reasoning": {
-          "supported": true,
-          "default_enabled": false,
-          "mode": "effort",
-          "effort": "none",
-          "effort_options": [
-            "none",
-            "low",
-            "medium",
-            "high",
-            "xhigh"
-          ],
-          "verbosity": "medium",
-          "verbosity_options": [
-            "low",
-            "medium",
-            "high"
-          ],
-          "visibility": "hidden"
-        }
-      }
-    },
-    {
-      "id": "gpt-5.4-pro",
-      "name": "GPT-5.4 Pro",
-      "family": "gpt-pro",
-      "display_name": "GPT-5.4 Pro",
-      "type": "chat",
-      "attachment": true,
-      "reasoning": {
-        "supported": true,
-        "default": true
-      },
-      "temperature": false,
-      "tool_call": true,
-      "structured_output": false,
-      "knowledge": "2025-08-31",
-      "release_date": "2026-03-05",
-      "last_updated": "2026-03-05",
-      "open_weights": false,
-      "modalities": {
-        "input": [
-          "text",
-          "image",
-          "pdf"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "cost": {
-        "input": 30,
-        "output": 180
-      },
-      "limit": {
-        "context": 1050000,
-        "output": 128000
-      },
-      "metadata": {
-        "selection": [
-          "sota",
-          "frontier",
-          "reasoning"
-        ],
-        "lifecycle": "active",
-        "sourceProvider": "openai",
-        "sourceProviderName": "OpenAI",
-        "sourceApiUrl": "https://api.openai.com/v1/models",
-        "sourceDocs": [
-          "https://developers.openai.com/api/docs/models",
-          "https://developers.openai.com/api/docs/guides/latest-model",
-          "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
-          "https://developers.openai.com/api/docs/models/gpt-5.6-terra",
-          "https://developers.openai.com/api/docs/models/gpt-5.6-luna",
-          "https://developers.openai.com/api/docs/models/gpt-5.4",
-          "https://developers.openai.com/api/docs/models/gpt-5.3-codex"
-        ],
-        "sourceStatus": "seed",
-        "apiListed": false,
-        "source": "public-provider-conf"
-      },
-      "vision": true,
-      "extra_capabilities": {
-        "reasoning": {
-          "supported": true,
-          "default_enabled": true,
-          "mode": "effort",
-          "effort": "high",
-          "effort_options": [
-            "medium",
-            "high",
-            "xhigh"
-          ],
-          "verbosity": "medium",
-          "verbosity_options": [
-            "low",
-            "medium",
-            "high"
-          ],
-          "visibility": "hidden"
+          "effort": "max"
         }
       }
     },
@@ -1892,8 +1416,7 @@
           "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
           "https://developers.openai.com/api/docs/models/gpt-5.6-terra",
           "https://developers.openai.com/api/docs/models/gpt-5.6-luna",
-          "https://developers.openai.com/api/docs/models/gpt-5.4",
-          "https://developers.openai.com/api/docs/models/gpt-5.3-codex"
+          "https://developers.openai.com/api/docs/models/gpt-5.5"
         ],
         "sourceStatus": "seed",
         "apiListed": false,
@@ -1995,8 +1518,7 @@
           "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
           "https://developers.openai.com/api/docs/models/gpt-5.6-terra",
           "https://developers.openai.com/api/docs/models/gpt-5.6-luna",
-          "https://developers.openai.com/api/docs/models/gpt-5.4",
-          "https://developers.openai.com/api/docs/models/gpt-5.3-codex"
+          "https://developers.openai.com/api/docs/models/gpt-5.5"
         ],
         "sourceStatus": "seed",
         "apiListed": false,
@@ -2101,8 +1623,7 @@
           "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
           "https://developers.openai.com/api/docs/models/gpt-5.6-terra",
           "https://developers.openai.com/api/docs/models/gpt-5.6-luna",
-          "https://developers.openai.com/api/docs/models/gpt-5.4",
-          "https://developers.openai.com/api/docs/models/gpt-5.3-codex"
+          "https://developers.openai.com/api/docs/models/gpt-5.5"
         ],
         "sourceStatus": "seed",
         "apiListed": false,
@@ -2206,8 +1727,7 @@
           "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
           "https://developers.openai.com/api/docs/models/gpt-5.6-terra",
           "https://developers.openai.com/api/docs/models/gpt-5.6-luna",
-          "https://developers.openai.com/api/docs/models/gpt-5.4",
-          "https://developers.openai.com/api/docs/models/gpt-5.3-codex"
+          "https://developers.openai.com/api/docs/models/gpt-5.5"
         ],
         "sourceStatus": "seed",
         "apiListed": false,
@@ -2312,8 +1832,7 @@
           "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
           "https://developers.openai.com/api/docs/models/gpt-5.6-terra",
           "https://developers.openai.com/api/docs/models/gpt-5.6-luna",
-          "https://developers.openai.com/api/docs/models/gpt-5.4",
-          "https://developers.openai.com/api/docs/models/gpt-5.3-codex"
+          "https://developers.openai.com/api/docs/models/gpt-5.5"
         ],
         "sourceStatus": "seed",
         "apiListed": false,
@@ -2345,76 +1864,6 @@
       }
     },
     {
-      "id": "kimi-k2-thinking",
-      "name": "Kimi K2 Thinking",
-      "family": "kimi-thinking",
-      "display_name": "Kimi K2 Thinking",
-      "type": "chat",
-      "attachment": false,
-      "reasoning": {
-        "supported": true,
-        "default": true
-      },
-      "temperature": true,
-      "tool_call": true,
-      "structured_output": true,
-      "knowledge": "2024-08",
-      "release_date": "2025-11-06",
-      "last_updated": "2025-11-06",
-      "open_weights": true,
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "cost": {
-        "input": 0.6,
-        "output": 2.5,
-        "cache_read": 0.15
-      },
-      "limit": {
-        "context": 262144,
-        "output": 262144
-      },
-      "metadata": {
-        "selection": [
-          "deep-reasoning",
-          "multi-step-tools"
-        ],
-        "lifecycle": "active",
-        "sourceProvider": "kimi",
-        "sourceProviderName": "Kimi",
-        "sourceApiUrl": "https://api.moonshot.ai/v1/models",
-        "sourceDocs": [
-          "https://platform.moonshot.ai/",
-          "https://platform.kimi.ai/docs/pricing/chat",
-          "https://platform.moonshot.ai/docs/guide/use-kimi-k2-thinking-model.en-US"
-        ],
-        "sourceStatus": "seed",
-        "apiListed": false,
-        "source": "public-provider-conf"
-      },
-      "vision": false,
-      "interleaved": {
-        "field": "reasoning_content"
-      },
-      "extra_capabilities": {
-        "reasoning": {
-          "supported": true,
-          "interleaved": true,
-          "summaries": true,
-          "visibility": "summary",
-          "continuation": [
-            "thinking_blocks"
-          ],
-          "default_enabled": true
-        }
-      }
-    },
-    {
       "id": "kimi-k2.5",
       "name": "Kimi K2.5",
       "family": "kimi-k2.5",
@@ -2428,9 +1877,14 @@
       "temperature": false,
       "tool_call": true,
       "structured_output": true,
+      "reasoning_options": [
+        {
+          "type": "toggle"
+        }
+      ],
       "knowledge": "2025-01",
       "release_date": "2026-01-27",
-      "last_updated": "2026-01-27",
+      "last_updated": "2026-08-31",
       "open_weights": true,
       "modalities": {
         "input": [
@@ -2453,18 +1907,28 @@
       },
       "metadata": {
         "selection": [
+          "compatibility",
           "multimodal",
           "reasoning",
           "coding"
         ],
-        "lifecycle": "active",
+        "lifecycle": "legacy",
+        "apiStatus": "sunset-scheduled",
+        "officialSunsetDate": "2026-08-31",
+        "notes": [
+          "Retained for third-party metadata fallback. Kimi schedules full official API retirement for August 31, 2026; inclusion does not imply official availability. Pricing is historical."
+        ],
         "sourceProvider": "kimi",
         "sourceProviderName": "Kimi",
         "sourceApiUrl": "https://api.moonshot.ai/v1/models",
         "sourceDocs": [
-          "https://platform.moonshot.ai/",
-          "https://platform.kimi.ai/docs/pricing/chat",
-          "https://platform.moonshot.ai/docs/guide/use-kimi-k2-thinking-model.en-US"
+          "https://platform.kimi.ai/docs/models",
+          "https://platform.kimi.ai/docs/api/models-overview",
+          "https://platform.kimi.ai/docs/api/chat",
+          "https://platform.kimi.ai/docs/guide/kimi-k3-quickstart",
+          "https://platform.kimi.ai/docs/guide/kimi-k2-7-code-quickstart",
+          "https://platform.kimi.ai/docs/pricing/chat-k3",
+          "https://platform.kimi.ai/docs/pricing/chat-k27-code"
         ],
         "sourceStatus": "seed",
         "apiListed": false,
@@ -2482,6 +1946,9 @@
           "visibility": "summary",
           "continuation": [
             "thinking_blocks"
+          ],
+          "notes": [
+            "Temperature is fixed at 1.0 with thinking enabled and 0.6 with thinking disabled."
           ],
           "default_enabled": true
         }
@@ -2498,12 +1965,17 @@
         "supported": true,
         "default": true
       },
-      "temperature": true,
+      "temperature": false,
       "tool_call": true,
       "structured_output": true,
+      "reasoning_options": [
+        {
+          "type": "toggle"
+        }
+      ],
       "knowledge": "2025-01",
       "release_date": "2026-04-21",
-      "last_updated": "2026-04-21",
+      "last_updated": "2026-08-31",
       "open_weights": true,
       "modalities": {
         "input": [
@@ -2526,18 +1998,22 @@
       },
       "metadata": {
         "selection": [
-          "latest",
+          "multimodal",
           "coding",
-          "agentic"
+          "optional-thinking"
         ],
         "lifecycle": "active",
         "sourceProvider": "kimi",
         "sourceProviderName": "Kimi",
         "sourceApiUrl": "https://api.moonshot.ai/v1/models",
         "sourceDocs": [
-          "https://platform.moonshot.ai/",
-          "https://platform.kimi.ai/docs/pricing/chat",
-          "https://platform.moonshot.ai/docs/guide/use-kimi-k2-thinking-model.en-US"
+          "https://platform.kimi.ai/docs/models",
+          "https://platform.kimi.ai/docs/api/models-overview",
+          "https://platform.kimi.ai/docs/api/chat",
+          "https://platform.kimi.ai/docs/guide/kimi-k3-quickstart",
+          "https://platform.kimi.ai/docs/guide/kimi-k2-7-code-quickstart",
+          "https://platform.kimi.ai/docs/pricing/chat-k3",
+          "https://platform.kimi.ai/docs/pricing/chat-k27-code"
         ],
         "sourceStatus": "seed",
         "apiListed": false,
@@ -2553,6 +2029,9 @@
           "continuation": [
             "thinking_blocks"
           ],
+          "notes": [
+            "Temperature is fixed at 1.0 with thinking enabled and 0.6 with thinking disabled."
+          ],
           "interleaved": true,
           "summaries": true,
           "visibility": "summary",
@@ -2561,23 +2040,20 @@
       }
     },
     {
-      "id": "kimi-k2.7-code-highspeed",
-      "name": "Kimi K2.7 Code Highspeed",
-      "family": "kimi-k2.7-code-highspeed",
-      "display_name": "Kimi K2.7 Code Highspeed",
+      "id": "kimi-k2.7-code",
+      "name": "Kimi K2.7 Code",
+      "family": "kimi-k2.7-code",
+      "display_name": "Kimi K2.7 Code",
       "type": "chat",
       "attachment": true,
       "reasoning": {
         "supported": true,
         "default": true
       },
-      "temperature": true,
+      "temperature": false,
       "tool_call": true,
       "structured_output": true,
-      "knowledge": "2025-01",
-      "release_date": "2026-04-21",
-      "last_updated": "2026-04-21",
-      "open_weights": true,
+      "last_updated": "2026-08-31",
       "modalities": {
         "input": [
           "text",
@@ -2591,7 +2067,7 @@
       "cost": {
         "input": 0.95,
         "output": 4,
-        "cache_read": 0.16
+        "cache_read": 0.19
       },
       "limit": {
         "context": 262144,
@@ -2608,9 +2084,13 @@
         "sourceProviderName": "Kimi",
         "sourceApiUrl": "https://api.moonshot.ai/v1/models",
         "sourceDocs": [
-          "https://platform.moonshot.ai/",
-          "https://platform.kimi.ai/docs/pricing/chat",
-          "https://platform.moonshot.ai/docs/guide/use-kimi-k2-thinking-model.en-US"
+          "https://platform.kimi.ai/docs/models",
+          "https://platform.kimi.ai/docs/api/models-overview",
+          "https://platform.kimi.ai/docs/api/chat",
+          "https://platform.kimi.ai/docs/guide/kimi-k3-quickstart",
+          "https://platform.kimi.ai/docs/guide/kimi-k2-7-code-quickstart",
+          "https://platform.kimi.ai/docs/pricing/chat-k3",
+          "https://platform.kimi.ai/docs/pricing/chat-k27-code"
         ],
         "sourceStatus": "seed",
         "apiListed": false,
@@ -2625,6 +2105,90 @@
           "supported": true,
           "continuation": [
             "thinking_blocks"
+          ],
+          "notes": [
+            "Thinking is always enabled and preserved. Disabling thinking is unsupported; temperature is fixed at 1.0."
+          ],
+          "interleaved": true,
+          "summaries": true,
+          "visibility": "summary",
+          "default_enabled": true,
+          "mode": "fixed"
+        }
+      }
+    },
+    {
+      "id": "kimi-k2.7-code-highspeed",
+      "name": "Kimi K2.7 Code Highspeed",
+      "family": "kimi-k2.7-code-highspeed",
+      "display_name": "Kimi K2.7 Code Highspeed",
+      "type": "chat",
+      "attachment": true,
+      "reasoning": {
+        "supported": true,
+        "default": true
+      },
+      "temperature": false,
+      "tool_call": true,
+      "structured_output": true,
+      "knowledge": "2025-01",
+      "release_date": "2026-04-21",
+      "last_updated": "2026-08-31",
+      "open_weights": true,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "cost": {
+        "input": 1.9,
+        "output": 8,
+        "cache_read": 0.38
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "metadata": {
+        "selection": [
+          "latest",
+          "coding",
+          "agentic"
+        ],
+        "lifecycle": "active",
+        "sourceProvider": "kimi",
+        "sourceProviderName": "Kimi",
+        "sourceApiUrl": "https://api.moonshot.ai/v1/models",
+        "sourceDocs": [
+          "https://platform.kimi.ai/docs/models",
+          "https://platform.kimi.ai/docs/api/models-overview",
+          "https://platform.kimi.ai/docs/api/chat",
+          "https://platform.kimi.ai/docs/guide/kimi-k3-quickstart",
+          "https://platform.kimi.ai/docs/guide/kimi-k2-7-code-quickstart",
+          "https://platform.kimi.ai/docs/pricing/chat-k3",
+          "https://platform.kimi.ai/docs/pricing/chat-k27-code"
+        ],
+        "sourceStatus": "seed",
+        "apiListed": false,
+        "source": "public-provider-conf"
+      },
+      "vision": true,
+      "interleaved": {
+        "field": "reasoning_content"
+      },
+      "extra_capabilities": {
+        "reasoning": {
+          "supported": true,
+          "continuation": [
+            "thinking_blocks"
+          ],
+          "notes": [
+            "Thinking is always enabled and preserved. Disabling thinking is unsupported; temperature is fixed at 1.0."
           ],
           "interleaved": true,
           "summaries": true,
@@ -2650,9 +2214,6 @@
       "structured_output": true,
       "reasoning_options": [
         {
-          "type": "toggle"
-        },
-        {
           "type": "effort",
           "values": [
             "low",
@@ -2662,7 +2223,7 @@
         }
       ],
       "release_date": "2026-07-16",
-      "last_updated": "2026-07-16",
+      "last_updated": "2026-08-31",
       "open_weights": true,
       "modalities": {
         "input": [
@@ -2681,7 +2242,7 @@
       },
       "limit": {
         "context": 1048576,
-        "output": 131072
+        "output": 1048576
       },
       "metadata": {
         "selection": [
@@ -2695,9 +2256,13 @@
         "sourceProviderName": "Kimi",
         "sourceApiUrl": "https://api.moonshot.ai/v1/models",
         "sourceDocs": [
-          "https://platform.moonshot.ai/",
-          "https://platform.kimi.ai/docs/pricing/chat",
-          "https://platform.moonshot.ai/docs/guide/use-kimi-k2-thinking-model.en-US"
+          "https://platform.kimi.ai/docs/models",
+          "https://platform.kimi.ai/docs/api/models-overview",
+          "https://platform.kimi.ai/docs/api/chat",
+          "https://platform.kimi.ai/docs/guide/kimi-k3-quickstart",
+          "https://platform.kimi.ai/docs/guide/kimi-k2-7-code-quickstart",
+          "https://platform.kimi.ai/docs/pricing/chat-k3",
+          "https://platform.kimi.ai/docs/pricing/chat-k27-code"
         ],
         "sourceStatus": "seed",
         "apiListed": false,
@@ -2718,134 +2283,16 @@
           "continuation": [
             "thinking_blocks"
           ],
+          "notes": [
+            "Thinking is always enabled; reasoning_effort defaults to max.",
+            "max_completion_tokens defaults to 131072 and can reach 1048576 within the shared input/output context window."
+          ],
           "interleaved": true,
           "summaries": true,
           "visibility": "summary",
           "default_enabled": true,
           "mode": "effort",
-          "effort": "high"
-        }
-      }
-    },
-    {
-      "id": "MiniMax-M2.5",
-      "name": "MiniMax-M2.5",
-      "family": "minimax",
-      "display_name": "MiniMax-M2.5",
-      "type": "chat",
-      "attachment": false,
-      "reasoning": {
-        "supported": true,
-        "default": true
-      },
-      "temperature": true,
-      "tool_call": true,
-      "structured_output": false,
-      "release_date": "2026-02-12",
-      "last_updated": "2026-02-12",
-      "open_weights": true,
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "cost": {
-        "input": 0.3,
-        "output": 1.2,
-        "cache_read": 0.03,
-        "cache_write": 0.375
-      },
-      "limit": {
-        "context": 204800,
-        "output": 131072
-      },
-      "metadata": {
-        "selection": [
-          "coding",
-          "value",
-          "tool-use"
-        ],
-        "lifecycle": "active",
-        "sourceProvider": "minimax",
-        "sourceProviderName": "MiniMax",
-        "sourceDocs": [
-          "https://platform.minimax.io/docs/guides/models-intro",
-          "https://platform.minimax.io/docs/api-reference/api-overview",
-          "https://platform.minimax.io/docs/guides/text-ai-coding-tools"
-        ],
-        "sourceStatus": "seed",
-        "apiListed": false,
-        "source": "public-provider-conf"
-      },
-      "vision": false,
-      "extra_capabilities": {
-        "reasoning": {
-          "supported": true,
-          "default_enabled": true
-        }
-      }
-    },
-    {
-      "id": "MiniMax-M2.5-highspeed",
-      "name": "MiniMax-M2.5-highspeed",
-      "family": "minimax",
-      "display_name": "MiniMax-M2.5-highspeed",
-      "type": "chat",
-      "attachment": false,
-      "reasoning": {
-        "supported": true,
-        "default": true
-      },
-      "temperature": true,
-      "tool_call": true,
-      "structured_output": false,
-      "release_date": "2026-02-13",
-      "last_updated": "2026-02-13",
-      "open_weights": true,
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "cost": {
-        "input": 0.6,
-        "output": 2.4,
-        "cache_read": 0.06,
-        "cache_write": 0.375
-      },
-      "limit": {
-        "context": 204800,
-        "output": 131072
-      },
-      "metadata": {
-        "selection": [
-          "fast",
-          "coding",
-          "tool-use"
-        ],
-        "lifecycle": "active",
-        "sourceProvider": "minimax",
-        "sourceProviderName": "MiniMax",
-        "sourceDocs": [
-          "https://platform.minimax.io/docs/guides/models-intro",
-          "https://platform.minimax.io/docs/api-reference/api-overview",
-          "https://platform.minimax.io/docs/guides/text-ai-coding-tools"
-        ],
-        "sourceStatus": "seed",
-        "apiListed": false,
-        "source": "public-provider-conf"
-      },
-      "vision": false,
-      "extra_capabilities": {
-        "reasoning": {
-          "supported": true,
-          "default_enabled": true
+          "effort": "max"
         }
       }
     },
@@ -3053,6 +2500,758 @@
           "interleaved": true,
           "summaries": true,
           "visibility": "summary"
+        }
+      }
+    },
+    {
+      "id": "qwen3-coder-flash",
+      "name": "Qwen3 Coder Flash",
+      "family": "qwen-coder",
+      "display_name": "Qwen3 Coder Flash",
+      "type": "chat",
+      "attachment": false,
+      "reasoning": {
+        "supported": false
+      },
+      "temperature": true,
+      "tool_call": true,
+      "structured_output": false,
+      "last_updated": "2026-08-31",
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "cost": {
+        "input": 0.3,
+        "output": 1.5,
+        "cache_read": 0.03,
+        "cache_write": 0.375
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 65536
+      },
+      "metadata": {
+        "selection": [
+          "coding",
+          "agentic"
+        ],
+        "lifecycle": "active",
+        "pricingRegion": "Singapore",
+        "pricingScope": "International",
+        "pricingBasis": "input-up-to-32k",
+        "notes": [
+          "Tool support follows the Qwen function-calling guide; hosted model cards list regional restrictions. Coder models do not expose thinking controls.",
+          "Cache prices, when present, refer to explicit caching. Longer inputs may use higher pricing tiers."
+        ],
+        "sourceProvider": "qwen",
+        "sourceProviderName": "Qwen",
+        "sourceDocs": [
+          "https://www.alibabacloud.com/help/en/model-studio/models",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-8-max",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-7-plus",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-8-flash",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-plus",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-flash",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-next",
+          "https://www.alibabacloud.com/help/en/model-studio/deep-thinking",
+          "https://www.alibabacloud.com/help/en/model-studio/qwen-function-calling",
+          "https://huggingface.co/Qwen/Qwen3-Coder-Next"
+        ],
+        "sourceStatus": "seed",
+        "apiListed": false,
+        "source": "public-provider-conf"
+      },
+      "vision": false,
+      "extra_capabilities": {
+        "reasoning": {
+          "supported": false,
+          "default_enabled": false
+        }
+      }
+    },
+    {
+      "id": "qwen3-coder-next",
+      "name": "Qwen3 Coder Next",
+      "family": "qwen-coder",
+      "display_name": "Qwen3 Coder Next",
+      "type": "chat",
+      "attachment": false,
+      "reasoning": {
+        "supported": false
+      },
+      "temperature": true,
+      "tool_call": true,
+      "structured_output": false,
+      "last_updated": "2026-08-31",
+      "open_weights": true,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "cost": {
+        "input": 0.3,
+        "output": 1.5
+      },
+      "limit": {
+        "context": 262144,
+        "output": 65536
+      },
+      "metadata": {
+        "selection": [
+          "coding",
+          "agentic"
+        ],
+        "lifecycle": "active",
+        "pricingRegion": "Singapore",
+        "pricingScope": "International",
+        "pricingBasis": "input-up-to-32k",
+        "notes": [
+          "Tool support follows the Qwen function-calling guide; hosted model cards list regional restrictions. Coder models do not expose thinking controls.",
+          "Cache prices, when present, refer to explicit caching. Longer inputs may use higher pricing tiers."
+        ],
+        "sourceProvider": "qwen",
+        "sourceProviderName": "Qwen",
+        "sourceDocs": [
+          "https://www.alibabacloud.com/help/en/model-studio/models",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-8-max",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-7-plus",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-8-flash",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-plus",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-flash",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-next",
+          "https://www.alibabacloud.com/help/en/model-studio/deep-thinking",
+          "https://www.alibabacloud.com/help/en/model-studio/qwen-function-calling",
+          "https://huggingface.co/Qwen/Qwen3-Coder-Next"
+        ],
+        "sourceStatus": "seed",
+        "apiListed": false,
+        "source": "public-provider-conf"
+      },
+      "vision": false,
+      "extra_capabilities": {
+        "reasoning": {
+          "supported": false,
+          "default_enabled": false
+        }
+      }
+    },
+    {
+      "id": "qwen3-coder-plus",
+      "name": "Qwen3 Coder Plus",
+      "family": "qwen-coder",
+      "display_name": "Qwen3 Coder Plus",
+      "type": "chat",
+      "attachment": false,
+      "reasoning": {
+        "supported": false
+      },
+      "temperature": true,
+      "tool_call": true,
+      "structured_output": false,
+      "last_updated": "2026-08-31",
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "cost": {
+        "input": 1,
+        "output": 5,
+        "cache_read": 0.1,
+        "cache_write": 1.25
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 65536
+      },
+      "metadata": {
+        "selection": [
+          "coding",
+          "agentic"
+        ],
+        "lifecycle": "active",
+        "pricingRegion": "Singapore",
+        "pricingScope": "International",
+        "pricingBasis": "input-up-to-32k",
+        "notes": [
+          "Tool support follows the Qwen function-calling guide; hosted model cards list regional restrictions. Coder models do not expose thinking controls.",
+          "Cache prices, when present, refer to explicit caching. Longer inputs may use higher pricing tiers."
+        ],
+        "sourceProvider": "qwen",
+        "sourceProviderName": "Qwen",
+        "sourceDocs": [
+          "https://www.alibabacloud.com/help/en/model-studio/models",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-8-max",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-7-plus",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-8-flash",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-plus",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-flash",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-next",
+          "https://www.alibabacloud.com/help/en/model-studio/deep-thinking",
+          "https://www.alibabacloud.com/help/en/model-studio/qwen-function-calling",
+          "https://huggingface.co/Qwen/Qwen3-Coder-Next"
+        ],
+        "sourceStatus": "seed",
+        "apiListed": false,
+        "source": "public-provider-conf"
+      },
+      "vision": false,
+      "extra_capabilities": {
+        "reasoning": {
+          "supported": false,
+          "default_enabled": false
+        }
+      }
+    },
+    {
+      "id": "qwen3.7-plus",
+      "name": "Qwen3.7 Plus",
+      "family": "qwen",
+      "display_name": "Qwen3.7 Plus",
+      "type": "chat",
+      "attachment": true,
+      "reasoning": {
+        "supported": true,
+        "default": true
+      },
+      "temperature": true,
+      "tool_call": true,
+      "structured_output": true,
+      "reasoning_options": [
+        {
+          "type": "toggle"
+        },
+        {
+          "type": "budget"
+        }
+      ],
+      "last_updated": "2026-08-31",
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "cost": {
+        "input": 0.4,
+        "output": 1.6,
+        "cache_read": 0.04,
+        "cache_write": 0.5
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 131072
+      },
+      "metadata": {
+        "selection": [
+          "multimodal",
+          "reasoning",
+          "coding"
+        ],
+        "lifecycle": "active",
+        "pricingRegion": "Singapore",
+        "pricingScope": "International",
+        "pricingBasis": "input-up-to-256k",
+        "notes": [
+          "Thinking mode has a 983616-token input limit and a separate 262144-token reasoning budget.",
+          "Cache prices refer to explicit caching. Longer inputs may use higher pricing tiers."
+        ],
+        "sourceProvider": "qwen",
+        "sourceProviderName": "Qwen",
+        "sourceDocs": [
+          "https://www.alibabacloud.com/help/en/model-studio/models",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-8-max",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-7-plus",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-8-flash",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-plus",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-flash",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-next",
+          "https://www.alibabacloud.com/help/en/model-studio/deep-thinking",
+          "https://www.alibabacloud.com/help/en/model-studio/qwen-function-calling",
+          "https://huggingface.co/Qwen/Qwen3-Coder-Next"
+        ],
+        "sourceStatus": "seed",
+        "apiListed": false,
+        "source": "public-provider-conf"
+      },
+      "vision": true,
+      "interleaved": {
+        "field": "reasoning_content"
+      },
+      "extra_capabilities": {
+        "reasoning": {
+          "supported": true,
+          "budget": {
+            "max": 262144,
+            "default": 262144,
+            "unit": "tokens"
+          },
+          "continuation": [
+            "thinking_blocks"
+          ],
+          "notes": [
+            "enable_thinking toggles reasoning; thinking_budget caps it. Set preserve_thinking=true to retain reasoning_content across turns."
+          ],
+          "interleaved": true,
+          "summaries": true,
+          "visibility": "summary",
+          "default_enabled": true,
+          "mode": "budget"
+        }
+      }
+    },
+    {
+      "id": "qwen3.8-flash",
+      "name": "Qwen3.8 Flash",
+      "family": "qwen",
+      "display_name": "Qwen3.8 Flash",
+      "type": "chat",
+      "attachment": true,
+      "reasoning": {
+        "supported": true,
+        "default": true
+      },
+      "temperature": true,
+      "tool_call": true,
+      "structured_output": true,
+      "reasoning_options": [
+        {
+          "type": "toggle"
+        },
+        {
+          "type": "budget"
+        }
+      ],
+      "last_updated": "2026-08-31",
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "cost": {
+        "input": 0.15,
+        "output": 0.47,
+        "cache_read": 0.016,
+        "cache_write": 0.2
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 131072
+      },
+      "metadata": {
+        "selection": [
+          "multimodal",
+          "reasoning",
+          "coding"
+        ],
+        "lifecycle": "active",
+        "pricingRegion": "Singapore",
+        "pricingScope": "International",
+        "pricingBasis": "standard",
+        "notes": [
+          "Thinking mode has a 983616-token input limit and a separate 262144-token reasoning budget.",
+          "Cache prices refer to explicit caching. Longer inputs may use higher pricing tiers."
+        ],
+        "sourceProvider": "qwen",
+        "sourceProviderName": "Qwen",
+        "sourceDocs": [
+          "https://www.alibabacloud.com/help/en/model-studio/models",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-8-max",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-7-plus",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-8-flash",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-plus",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-flash",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-next",
+          "https://www.alibabacloud.com/help/en/model-studio/deep-thinking",
+          "https://www.alibabacloud.com/help/en/model-studio/qwen-function-calling",
+          "https://huggingface.co/Qwen/Qwen3-Coder-Next"
+        ],
+        "sourceStatus": "seed",
+        "apiListed": false,
+        "source": "public-provider-conf"
+      },
+      "vision": true,
+      "interleaved": {
+        "field": "reasoning_content"
+      },
+      "extra_capabilities": {
+        "reasoning": {
+          "supported": true,
+          "budget": {
+            "max": 262144,
+            "default": 262144,
+            "unit": "tokens"
+          },
+          "continuation": [
+            "thinking_blocks"
+          ],
+          "notes": [
+            "enable_thinking toggles reasoning; thinking_budget caps it. Set preserve_thinking=true to retain reasoning_content across turns."
+          ],
+          "interleaved": true,
+          "summaries": true,
+          "visibility": "summary",
+          "default_enabled": true,
+          "mode": "budget"
+        }
+      }
+    },
+    {
+      "id": "qwen3.8-max",
+      "name": "Qwen3.8 Max",
+      "family": "qwen",
+      "display_name": "Qwen3.8 Max",
+      "type": "chat",
+      "attachment": true,
+      "reasoning": {
+        "supported": true,
+        "default": true
+      },
+      "temperature": true,
+      "tool_call": true,
+      "structured_output": true,
+      "reasoning_options": [
+        {
+          "type": "toggle"
+        },
+        {
+          "type": "budget"
+        }
+      ],
+      "last_updated": "2026-08-31",
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "cost": {
+        "input": 2,
+        "output": 6,
+        "cache_read": 0.17,
+        "cache_write": 2.5
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 131072
+      },
+      "metadata": {
+        "selection": [
+          "multimodal",
+          "reasoning",
+          "coding"
+        ],
+        "lifecycle": "active",
+        "pricingRegion": "Singapore",
+        "pricingScope": "International",
+        "pricingBasis": "standard",
+        "notes": [
+          "Thinking mode has a 983616-token input limit and a separate 262144-token reasoning budget.",
+          "Cache prices refer to explicit caching. Longer inputs may use higher pricing tiers."
+        ],
+        "sourceProvider": "qwen",
+        "sourceProviderName": "Qwen",
+        "sourceDocs": [
+          "https://www.alibabacloud.com/help/en/model-studio/models",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-8-max",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-7-plus",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-8-flash",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-plus",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-flash",
+          "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-next",
+          "https://www.alibabacloud.com/help/en/model-studio/deep-thinking",
+          "https://www.alibabacloud.com/help/en/model-studio/qwen-function-calling",
+          "https://huggingface.co/Qwen/Qwen3-Coder-Next"
+        ],
+        "sourceStatus": "seed",
+        "apiListed": false,
+        "source": "public-provider-conf"
+      },
+      "vision": true,
+      "interleaved": {
+        "field": "reasoning_content"
+      },
+      "extra_capabilities": {
+        "reasoning": {
+          "supported": true,
+          "budget": {
+            "max": 262144,
+            "default": 262144,
+            "unit": "tokens"
+          },
+          "continuation": [
+            "thinking_blocks"
+          ],
+          "notes": [
+            "enable_thinking toggles reasoning; thinking_budget caps it. Set preserve_thinking=true to retain reasoning_content across turns."
+          ],
+          "interleaved": true,
+          "summaries": true,
+          "visibility": "summary",
+          "default_enabled": true,
+          "mode": "budget"
+        }
+      }
+    },
+    {
+      "id": "step-3.5-flash",
+      "name": "Step 3.5 Flash",
+      "family": "step",
+      "display_name": "Step 3.5 Flash",
+      "type": "chat",
+      "attachment": false,
+      "reasoning": {
+        "supported": true,
+        "default": true
+      },
+      "temperature": true,
+      "tool_call": true,
+      "structured_output": true,
+      "last_updated": "2026-08-31",
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "cost": {
+        "input": 0.1,
+        "output": 0.3,
+        "cache_read": 0.02
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "metadata": {
+        "selection": [
+          "coding",
+          "reasoning",
+          "cost-efficient"
+        ],
+        "lifecycle": "active",
+        "notes": [
+          "max_tokens is bounded by the shared input/output context window. Structured output support refers to JSON mode."
+        ],
+        "sourceProvider": "stepfun",
+        "sourceProviderName": "StepFun",
+        "sourceDocs": [
+          "https://platform.stepfun.ai/docs/en/guides/models/step-3.7-flash",
+          "https://platform.stepfun.ai/docs/en/guides/models/step-3.5-flash",
+          "https://platform.stepfun.ai/docs/en/api-reference/chat/chat-completion-create",
+          "https://platform.stepfun.ai/docs/en/guides/developer/reasoning",
+          "https://platform.stepfun.ai/docs/en/guides/pricing/details",
+          "https://huggingface.co/stepfun-ai/Step-3.7-Flash"
+        ],
+        "sourceStatus": "seed",
+        "apiListed": false,
+        "source": "public-provider-conf"
+      },
+      "vision": false,
+      "extra_capabilities": {
+        "reasoning": {
+          "supported": true,
+          "default_enabled": true,
+          "mode": "fixed",
+          "notes": [
+            "The API returns reasoning by default; reasoning_format=deepseek-style switches the response field to reasoning_content."
+          ]
+        }
+      }
+    },
+    {
+      "id": "step-3.5-flash-2603",
+      "name": "Step 3.5 Flash 2603",
+      "family": "step",
+      "display_name": "Step 3.5 Flash 2603",
+      "type": "chat",
+      "attachment": false,
+      "reasoning": {
+        "supported": true,
+        "default": true
+      },
+      "temperature": true,
+      "tool_call": true,
+      "structured_output": true,
+      "reasoning_options": [
+        {
+          "type": "effort",
+          "values": [
+            "low",
+            "high"
+          ]
+        }
+      ],
+      "last_updated": "2026-08-31",
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "cost": {
+        "input": 0.1,
+        "output": 0.3,
+        "cache_read": 0.02
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "metadata": {
+        "selection": [
+          "coding",
+          "reasoning",
+          "cost-efficient"
+        ],
+        "lifecycle": "active",
+        "notes": [
+          "max_tokens is bounded by the shared input/output context window. Structured output support refers to JSON mode."
+        ],
+        "sourceProvider": "stepfun",
+        "sourceProviderName": "StepFun",
+        "sourceDocs": [
+          "https://platform.stepfun.ai/docs/en/guides/models/step-3.7-flash",
+          "https://platform.stepfun.ai/docs/en/guides/models/step-3.5-flash",
+          "https://platform.stepfun.ai/docs/en/api-reference/chat/chat-completion-create",
+          "https://platform.stepfun.ai/docs/en/guides/developer/reasoning",
+          "https://platform.stepfun.ai/docs/en/guides/pricing/details",
+          "https://huggingface.co/stepfun-ai/Step-3.7-Flash"
+        ],
+        "sourceStatus": "seed",
+        "apiListed": false,
+        "source": "public-provider-conf"
+      },
+      "vision": false,
+      "extra_capabilities": {
+        "reasoning": {
+          "supported": true,
+          "default_enabled": true,
+          "mode": "effort",
+          "effort_options": [
+            "low",
+            "high"
+          ],
+          "notes": [
+            "The API returns reasoning by default; reasoning_format=deepseek-style switches the response field to reasoning_content."
+          ]
+        }
+      }
+    },
+    {
+      "id": "step-3.7-flash",
+      "name": "Step 3.7 Flash",
+      "family": "step",
+      "display_name": "Step 3.7 Flash",
+      "type": "chat",
+      "attachment": true,
+      "reasoning": {
+        "supported": true,
+        "default": true
+      },
+      "temperature": true,
+      "tool_call": true,
+      "structured_output": true,
+      "reasoning_options": [
+        {
+          "type": "effort",
+          "values": [
+            "low",
+            "medium",
+            "high"
+          ]
+        }
+      ],
+      "last_updated": "2026-08-31",
+      "open_weights": true,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "cost": {
+        "input": 0.2,
+        "output": 1.15,
+        "cache_read": 0.04
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "metadata": {
+        "selection": [
+          "latest",
+          "multimodal",
+          "coding",
+          "reasoning"
+        ],
+        "lifecycle": "active",
+        "notes": [
+          "max_tokens is bounded by the shared input/output context window. Structured output support refers to JSON mode."
+        ],
+        "sourceProvider": "stepfun",
+        "sourceProviderName": "StepFun",
+        "sourceDocs": [
+          "https://platform.stepfun.ai/docs/en/guides/models/step-3.7-flash",
+          "https://platform.stepfun.ai/docs/en/guides/models/step-3.5-flash",
+          "https://platform.stepfun.ai/docs/en/api-reference/chat/chat-completion-create",
+          "https://platform.stepfun.ai/docs/en/guides/developer/reasoning",
+          "https://platform.stepfun.ai/docs/en/guides/pricing/details",
+          "https://huggingface.co/stepfun-ai/Step-3.7-Flash"
+        ],
+        "sourceStatus": "seed",
+        "apiListed": false,
+        "source": "public-provider-conf"
+      },
+      "vision": true,
+      "extra_capabilities": {
+        "reasoning": {
+          "supported": true,
+          "default_enabled": true,
+          "mode": "effort",
+          "effort": "medium",
+          "effort_options": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "notes": [
+            "The API returns reasoning by default; reasoning_format=deepseek-style switches the response field to reasoning_content."
+          ]
         }
       }
     }

--- a/docs/custom-provider.md
+++ b/docs/custom-provider.md
@@ -6,17 +6,38 @@ It combines compact, high-signal model cards from official sources into a normal
 - `dist/custom-provider.json`
 - `dist/all.json` provider entry: `custom-provider`
 
-The catalog is intentionally focused on current chat, coding, reasoning, and frontier models. It is designed to be used before AIHubMix, while AIHubMix remains available as the broader lower-tier fallback source.
+The catalog contains 37 selected chat, coding, reasoning, and frontier models across nine sources. It is designed to be used before AIHubMix, while AIHubMix remains available as the broader lower-tier fallback source. Inclusion provides capability metadata; it does not guarantee that an official or third-party endpoint serves the model.
 
-## Official Sources
+## Selected Models
 
-- OpenAI
-- Anthropic
-- Google Gemini
-- Kimi / Moonshot
-- DeepSeek
-- Zhipu GLM
-- MiniMax
+The maintained selection is dated August 31, 2026. Model IDs are exact API identifiers; product names and release dates are not synthesized into additional aliases.
+
+| Official source | Count | Model IDs |
+| --- | ---: | --- |
+| [OpenAI](https://developers.openai.com/api/docs/models) | 5 | `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5` |
+| [Anthropic](https://platform.claude.com/docs/en/about-claude/models/overview) | 4 | `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`, `claude-haiku-4-5` |
+| [Google Gemini](https://ai.google.dev/gemini-api/docs/models) | 5 | `gemini-3.1-pro-preview`, `gemini-3.7-flash`, `gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite` |
+| [Kimi / Moonshot](https://platform.kimi.ai/docs/models) | 5 | `kimi-k3`, `kimi-k2.7-code`, `kimi-k2.7-code-highspeed`, `kimi-k2.6`, `kimi-k2.5` |
+| [DeepSeek](https://api-docs.deepseek.com/quick_start/pricing/) | 3 | `deepseek-v4-flash`, `deepseek-v4-pro`, `deepseek-v4-flash-vision-exp` |
+| [Zhipu GLM](https://docs.z.ai/guides/overview/pricing) | 3 | `glm-5.3`, `glm-5.3-flash`, `glm-5.2` |
+| [MiniMax](https://platform.minimax.io/docs/guides/models-intro) | 3 | `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed` |
+| [StepFun](https://platform.stepfun.ai/docs/en/guides/models/step-3.7-flash) | 3 | `step-3.7-flash`, `step-3.5-flash-2603`, `step-3.5-flash` |
+| [Qwen](https://www.alibabacloud.com/help/en/model-studio/models) | 6 | `qwen3.8-max`, `qwen3.7-plus`, `qwen3.8-flash`, `qwen3-coder-plus`, `qwen3-coder-flash`, `qwen3-coder-next` |
+
+Selection favors current models while keeping explicit compatibility coverage: GPT-5.5, Gemini Flash back through 3.5, Gemini 3.1 Pro Preview, and Kimi K2.5. Kimi K2.6 and GLM-5.2 also retain support for disabling thinking. Models outside this table are excluded from this fallback catalog, regardless of whether their upstream API remains available.
+
+Kimi K2.5 is a compatibility entry with `metadata.lifecycle = "legacy"`, `metadata.apiStatus = "sunset-scheduled"`, and `metadata.officialSunsetDate = "2026-08-31"`. Kimi's official model list schedules its full API retirement for that date. Its metadata and historical pricing remain available for third-party providers; it is not marked as an active official API model. Preview and experimental entries retain their lifecycle annotations.
+
+## Capability And Pricing Notes
+
+- Gemini 3.7 Flash accepts `low`, `medium`, and `high` thinking levels, with `medium` as the default. `minimal` is unsupported. Earlier retained Flash models keep their own controls.
+- DeepSeek V4 Flash and Pro both expose the effective reasoning levels `low`, `high`, and `max`, defaulting to `high`. The API maps `medium` and `xhigh` to `high`. Temperature affects only non-thinking requests.
+- Kimi K3 always thinks and defaults to `max` effort. Its output ceiling is 1,048,576 tokens; 131,072 is the default, and input plus requested output must fit the shared context window. Both K2.7 Code variants also always think. Kimi sampling temperatures are fixed by model and thinking mode.
+- GLM-5.3 and GLM-5.3-Flash always think and expose `low`, `high`, and `max` effort. Flash accepts image, video, text, and file input. GLM-5.2 retains optional thinking.
+- Step 3.7 Flash supports image/video input and `low`, `medium`, and `high` reasoning effort. Step 3.5 Flash 2603 supports `low` and `high`; the base 3.5 entry does not advertise effort controls. StepFun returns reasoning in the `reasoning` field by default; `reasoning_format=deepseek-style` selects `reasoning_content`. Output shares the context window, and structured output support refers to JSON mode.
+- Qwen3.8 Max/Flash and Qwen3.7 Plus support thinking toggles and token budgets. Their thinking input limit is 983,616 tokens, and their maximum reasoning budget is 262,144 tokens. Qwen Coder entries do not advertise thinking controls. Tool support follows Qwen's function-calling guide; hosted model cards list regional restrictions, so endpoint-specific capabilities take precedence over this fallback metadata.
+
+Costs are documentation snapshots in USD per million tokens. DeepSeek uses peak prices; off-peak rates are half those values. Qwen uses Singapore International pricing and explicit cache rates, with the input tier recorded in `metadata.pricingBasis`. Gemini 3.7 Flash and GLM-5.3-Flash include time-limited prices annotated with `metadata.pricingValidUntil`. The generator does not calculate regional tiers, discounts, or future prices.
 
 ## Environment Variables
 
@@ -28,7 +49,7 @@ The generator uses official list APIs when keys are available:
 - `MOONSHOT_API_KEY`
 - `DEEPSEEK_API_KEY`
 
-Zhipu GLM and MiniMax currently use official documentation-derived seeds because the maintained catalog needs capability fields that are not exposed through a stable public model-list API in this repository.
+Zhipu GLM, MiniMax, StepFun, and Qwen use official documentation-derived seeds. StepFun and Qwen reuse the existing seed adapter without network discovery or additional API keys.
 
 Missing API keys only skip that source's live API refresh. The provider still uses the maintained official documentation-derived seed entries for that source.
 
@@ -65,7 +86,9 @@ This file is excluded from manual template provider loading and is consumed by t
 
 Official model list APIs are used as an availability/enrichment signal. When those APIs return only basic model IDs, the generator preserves the seed capability metadata and annotates model metadata with API listing status.
 
-Models announced in official OpenAI product surfaces before stable API documentation may be included as provisional seeds. These entries carry `metadata.apiStatus = "coming-soon"` and should be updated once stable API limits, pricing, and model docs are published.
+Only selected seed IDs are enriched. An unselected model returned by an API cannot enter the catalog, and a missing API listing does not remove a compatibility seed. `metadata.apiListed` records discovery status separately from lifecycle metadata.
+
+When maintaining the selection, verify exact model IDs and capabilities against the source's official documentation, keep `maxModels` aligned with the selected count, and update the table above. Preserve source URLs and any model-specific limits or lifecycle notes. Unknown release dates, prices, and capabilities should be omitted rather than copied from a neighboring model.
 
 ## Logging
 
@@ -80,4 +103,6 @@ Custom provider generation:
   DeepSeek: N selected
   Zhipu: N selected
   MiniMax: N selected
+  StepFun: N selected
+  Qwen: N selected
 ```

--- a/manual-templates/custom-provider-overrides.json
+++ b/manual-templates/custom-provider-overrides.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-08-21T00:00:00.000Z",
+  "updatedAt": "2026-08-31T00:00:00.000Z",
   "maxModels": 37,
   "provider": {
     "id": "custom-provider",
@@ -25,8 +25,7 @@
         "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
         "https://developers.openai.com/api/docs/models/gpt-5.6-terra",
         "https://developers.openai.com/api/docs/models/gpt-5.6-luna",
-        "https://developers.openai.com/api/docs/models/gpt-5.4",
-        "https://developers.openai.com/api/docs/models/gpt-5.3-codex"
+        "https://developers.openai.com/api/docs/models/gpt-5.5"
       ],
       "models": [
         {
@@ -224,176 +223,6 @@
             "availability": ["api", "chatgpt", "codex"]
           },
           "selectionRank": 5
-        },
-        {
-          "id": "gpt-5.4",
-          "name": "GPT-5.4",
-          "family": "gpt",
-          "contextLength": 1050000,
-          "maxTokens": 128000,
-          "vision": true,
-          "functionCall": true,
-          "reasoning": { "supported": true, "default": false },
-          "attachment": true,
-          "temperature": false,
-          "toolCall": true,
-          "structuredOutput": true,
-          "knowledge": "2025-08-31",
-          "releaseDate": "2026-03-05",
-          "lastUpdated": "2026-03-05",
-          "openWeights": false,
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-          "cost": { "input": 2.5, "output": 15, "cacheRead": 0.25 },
-          "extraCapabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": false,
-              "mode": "effort",
-              "effort": "none",
-              "effort_options": ["none", "low", "medium", "high", "xhigh"],
-              "verbosity": "medium",
-              "verbosity_options": ["low", "medium", "high"],
-              "visibility": "hidden"
-            }
-          },
-          "metadata": { "selection": ["frontier", "coding", "reasoning"], "lifecycle": "active" },
-          "selectionRank": 6
-        },
-        {
-          "id": "gpt-5.4-pro",
-          "name": "GPT-5.4 Pro",
-          "family": "gpt-pro",
-          "contextLength": 1050000,
-          "maxTokens": 128000,
-          "vision": true,
-          "functionCall": true,
-          "reasoning": { "supported": true, "default": true },
-          "attachment": true,
-          "temperature": false,
-          "toolCall": true,
-          "structuredOutput": false,
-          "knowledge": "2025-08-31",
-          "releaseDate": "2026-03-05",
-          "lastUpdated": "2026-03-05",
-          "openWeights": false,
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-          "cost": { "input": 30, "output": 180 },
-          "extraCapabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": true,
-              "mode": "effort",
-              "effort": "high",
-              "effort_options": ["medium", "high", "xhigh"],
-              "verbosity": "medium",
-              "verbosity_options": ["low", "medium", "high"],
-              "visibility": "hidden"
-            }
-          },
-          "metadata": { "selection": ["sota", "frontier", "reasoning"], "lifecycle": "active" },
-          "selectionRank": 7
-        },
-        {
-          "id": "gpt-5.4-mini",
-          "name": "GPT-5.4 Mini",
-          "family": "gpt",
-          "contextLength": 400000,
-          "maxTokens": 128000,
-          "vision": true,
-          "functionCall": true,
-          "reasoning": { "supported": true, "default": false },
-          "attachment": true,
-          "temperature": false,
-          "toolCall": true,
-          "structuredOutput": true,
-          "knowledge": "2025-08-31",
-          "releaseDate": "2026-03-17",
-          "lastUpdated": "2026-03-17",
-          "openWeights": false,
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-          "cost": { "input": 0.75, "output": 4.5, "cacheRead": 0.075 },
-          "extraCapabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": false,
-              "mode": "effort",
-              "effort": "none",
-              "effort_options": ["none", "low", "medium", "high", "xhigh"],
-              "verbosity": "medium",
-              "verbosity_options": ["low", "medium", "high"],
-              "visibility": "hidden"
-            }
-          },
-          "metadata": { "selection": ["fast", "coding", "cost-efficient"], "lifecycle": "active" },
-          "selectionRank": 8
-        },
-        {
-          "id": "gpt-5.4-nano",
-          "name": "GPT-5.4 Nano",
-          "family": "gpt",
-          "contextLength": 400000,
-          "maxTokens": 128000,
-          "vision": true,
-          "functionCall": true,
-          "reasoning": { "supported": true, "default": false },
-          "attachment": true,
-          "temperature": false,
-          "toolCall": true,
-          "structuredOutput": true,
-          "knowledge": "2025-08-31",
-          "releaseDate": "2026-03-17",
-          "lastUpdated": "2026-03-17",
-          "openWeights": false,
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-          "cost": { "input": 0.2, "output": 1.25, "cacheRead": 0.02 },
-          "extraCapabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": false,
-              "mode": "effort",
-              "effort": "none",
-              "effort_options": ["none", "low", "medium", "high", "xhigh"],
-              "verbosity": "medium",
-              "verbosity_options": ["low", "medium", "high"],
-              "visibility": "hidden"
-            }
-          },
-          "metadata": { "selection": ["small", "cost-efficient", "fallback"], "lifecycle": "active" },
-          "selectionRank": 9
-        },
-        {
-          "id": "gpt-5.3-codex",
-          "name": "GPT-5.3 Codex",
-          "family": "gpt-codex",
-          "contextLength": 400000,
-          "maxTokens": 128000,
-          "vision": true,
-          "functionCall": true,
-          "reasoning": { "supported": true, "default": true },
-          "attachment": true,
-          "temperature": false,
-          "toolCall": true,
-          "structuredOutput": true,
-          "knowledge": "2025-08-31",
-          "releaseDate": "2026-02-05",
-          "lastUpdated": "2026-02-05",
-          "openWeights": false,
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-          "cost": { "input": 1.75, "output": 14, "cacheRead": 0.175 },
-          "extraCapabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": true,
-              "mode": "effort",
-              "effort": "medium",
-              "effort_options": ["low", "medium", "high", "xhigh"],
-              "verbosity": "medium",
-              "verbosity_options": ["low", "medium", "high"],
-              "visibility": "hidden"
-            }
-          },
-          "metadata": { "selection": ["coding", "agentic", "reasoning"], "lifecycle": "active" },
-          "selectionRank": 10
         }
       ]
     },
@@ -542,7 +371,10 @@
       "apiKeyEnv": "GEMINI_API_KEY",
       "docs": [
         "https://ai.google.dev/gemini-api/docs/models",
-        "https://ai.google.dev/gemini-api/docs/gemini-3"
+        "https://ai.google.dev/gemini-api/docs/gemini-3",
+        "https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash",
+        "https://ai.google.dev/gemini-api/docs/latest-model",
+        "https://ai.google.dev/gemini-api/docs/pricing"
       ],
       "models": [
         {
@@ -580,6 +412,47 @@
           "selectionRank": 1
         },
         {
+          "id": "gemini-3.7-flash",
+          "name": "Gemini 3.7 Flash",
+          "family": "gemini-flash",
+          "contextLength": 1048576,
+          "maxTokens": 65536,
+          "vision": true,
+          "functionCall": true,
+          "reasoning": { "supported": true, "default": true },
+          "attachment": true,
+          "temperature": true,
+          "toolCall": true,
+          "structuredOutput": true,
+          "reasoningOptions": [
+            { "type": "effort", "values": ["low", "medium", "high"] }
+          ],
+          "lastUpdated": "2026-08-31",
+          "openWeights": false,
+          "modalities": { "input": ["text", "image", "video", "audio", "pdf"], "output": ["text"] },
+          "cost": { "input": 0.75, "output": 3.75, "cacheRead": 0.075 },
+          "extraCapabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "level",
+              "level": "medium",
+              "level_options": ["low", "medium", "high"],
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": ["thought_signatures"],
+              "notes": ["The thinkingLevel parameter does not accept minimal."]
+            }
+          },
+          "metadata": {
+            "selection": ["latest", "fast", "multimodal", "reasoning"],
+            "lifecycle": "active",
+            "pricingBasis": "standard-introductory",
+            "pricingValidUntil": "2026-12-31"
+          },
+          "selectionRank": 2
+        },
+        {
           "id": "gemini-3.6-flash",
           "name": "Gemini 3.6 Flash",
           "family": "gemini-flash",
@@ -613,8 +486,11 @@
               "continuation": ["thought_signatures"]
             }
           },
-          "metadata": { "selection": ["latest", "fast", "multimodal", "reasoning"], "lifecycle": "active" },
-          "selectionRank": 2
+          "metadata": {
+            "selection": ["fast", "multimodal", "reasoning"],
+            "lifecycle": "active"
+          },
+          "selectionRank": 3
         },
         {
           "id": "gemini-3.5-flash",
@@ -650,8 +526,11 @@
               "continuation": ["thought_signatures"]
             }
           },
-          "metadata": { "selection": ["fast", "multimodal", "reasoning"], "lifecycle": "active" },
-          "selectionRank": 3
+          "metadata": {
+            "selection": ["fast", "multimodal", "reasoning"],
+            "lifecycle": "active"
+          },
+          "selectionRank": 4
         },
         {
           "id": "gemini-3.5-flash-lite",
@@ -676,44 +555,12 @@
           "modalities": { "input": ["text", "image", "video", "audio", "pdf"], "output": ["text"] },
           "cost": { "input": 0.3, "output": 2.5, "cacheRead": 0.03 },
           "extraCapabilities": {
-            "reasoning": {
-              "supported": true
-            }
+            "reasoning": { "supported": true }
           },
-          "metadata": { "selection": ["fast", "cost-efficient", "multimodal"], "lifecycle": "active" },
-          "selectionRank": 4
-        },
-        {
-          "id": "gemini-2.5-pro",
-          "name": "Gemini 2.5 Pro",
-          "family": "gemini-pro",
-          "contextLength": 1048576,
-          "maxTokens": 65536,
-          "vision": true,
-          "functionCall": true,
-          "reasoning": { "supported": true, "default": true, "budget": { "min": 128, "max": 32768, "default": -1 } },
-          "attachment": true,
-          "temperature": true,
-          "toolCall": true,
-          "structuredOutput": true,
-          "knowledge": "2025-01",
-          "releaseDate": "2025-06-17",
-          "lastUpdated": "2025-06-17",
-          "openWeights": false,
-          "modalities": { "input": ["text", "image", "video", "audio", "pdf"], "output": ["text"] },
-          "cost": { "input": 1.25, "output": 10, "cacheRead": 0.125 },
-          "extraCapabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": true,
-              "mode": "budget",
-              "budget": { "min": 128, "max": 32768, "default": -1, "auto": -1, "unit": "tokens" },
-              "summaries": true,
-              "visibility": "summary",
-              "continuation": ["thought_signatures"]
-            }
+          "metadata": {
+            "selection": ["fast", "cost-efficient", "multimodal"],
+            "lifecycle": "active"
           },
-          "metadata": { "selection": ["stable", "deep-reasoning", "coding"], "lifecycle": "active" },
           "selectionRank": 5
         }
       ]
@@ -724,11 +571,92 @@
       "apiUrl": "https://api.moonshot.ai/v1/models",
       "apiKeyEnv": "MOONSHOT_API_KEY",
       "docs": [
-        "https://platform.moonshot.ai/",
-        "https://platform.kimi.ai/docs/pricing/chat",
-        "https://platform.moonshot.ai/docs/guide/use-kimi-k2-thinking-model.en-US"
+        "https://platform.kimi.ai/docs/models",
+        "https://platform.kimi.ai/docs/api/models-overview",
+        "https://platform.kimi.ai/docs/api/chat",
+        "https://platform.kimi.ai/docs/guide/kimi-k3-quickstart",
+        "https://platform.kimi.ai/docs/guide/kimi-k2-7-code-quickstart",
+        "https://platform.kimi.ai/docs/pricing/chat-k3",
+        "https://platform.kimi.ai/docs/pricing/chat-k27-code"
       ],
       "models": [
+        {
+          "id": "kimi-k3",
+          "name": "Kimi K3",
+          "family": "kimi-k3",
+          "contextLength": 1048576,
+          "maxTokens": 1048576,
+          "vision": true,
+          "functionCall": true,
+          "reasoning": { "supported": true, "default": true },
+          "attachment": true,
+          "temperature": false,
+          "toolCall": true,
+          "structuredOutput": true,
+          "reasoningOptions": [
+            { "type": "effort", "values": ["low", "high", "max"] }
+          ],
+          "releaseDate": "2026-07-16",
+          "lastUpdated": "2026-08-31",
+          "openWeights": true,
+          "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
+          "cost": { "input": 3, "output": 15, "cacheRead": 0.3 },
+          "interleaved": { "field": "reasoning_content" },
+          "extraCapabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "effort",
+              "effort": "max",
+              "effort_options": ["low", "high", "max"],
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": ["thinking_blocks"],
+              "notes": ["Thinking is always enabled; reasoning_effort defaults to max.", "max_completion_tokens defaults to 131072 and can reach 1048576 within the shared input/output context window."]
+            }
+          },
+          "metadata": {
+            "selection": ["latest", "multimodal", "long-context", "agentic"],
+            "lifecycle": "active"
+          },
+          "selectionRank": 1
+        },
+        {
+          "id": "kimi-k2.7-code",
+          "name": "Kimi K2.7 Code",
+          "family": "kimi-k2.7-code",
+          "contextLength": 262144,
+          "maxTokens": 262144,
+          "vision": true,
+          "functionCall": true,
+          "reasoning": { "supported": true, "default": true },
+          "attachment": true,
+          "temperature": false,
+          "toolCall": true,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-31",
+          "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
+          "cost": { "input": 0.95, "output": 4, "cacheRead": 0.19 },
+          "interleaved": { "field": "reasoning_content" },
+          "extraCapabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "fixed",
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": ["thinking_blocks"],
+              "notes": ["Thinking is always enabled and preserved. Disabling thinking is unsupported; temperature is fixed at 1.0."]
+            }
+          },
+          "metadata": {
+            "selection": ["latest", "coding", "agentic"],
+            "lifecycle": "active"
+          },
+          "selectionRank": 2
+        },
         {
           "id": "kimi-k2.7-code-highspeed",
           "name": "Kimi K2.7 Code Highspeed",
@@ -739,15 +667,15 @@
           "functionCall": true,
           "reasoning": { "supported": true, "default": true },
           "attachment": true,
-          "temperature": true,
+          "temperature": false,
           "toolCall": true,
           "structuredOutput": true,
           "knowledge": "2025-01",
           "releaseDate": "2026-04-21",
-          "lastUpdated": "2026-04-21",
+          "lastUpdated": "2026-08-31",
           "openWeights": true,
           "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
-          "cost": { "input": 0.95, "output": 4, "cacheRead": 0.16 },
+          "cost": { "input": 1.9, "output": 8, "cacheRead": 0.38 },
           "interleaved": { "field": "reasoning_content" },
           "extraCapabilities": {
             "reasoning": {
@@ -757,11 +685,15 @@
               "interleaved": true,
               "summaries": true,
               "visibility": "summary",
-              "continuation": ["thinking_blocks"]
+              "continuation": ["thinking_blocks"],
+              "notes": ["Thinking is always enabled and preserved. Disabling thinking is unsupported; temperature is fixed at 1.0."]
             }
           },
-          "metadata": { "selection": ["latest", "coding", "agentic"], "lifecycle": "active" },
-          "selectionRank": 2
+          "metadata": {
+            "selection": ["latest", "coding", "agentic"],
+            "lifecycle": "active"
+          },
+          "selectionRank": 3
         },
         {
           "id": "kimi-k2.6",
@@ -773,12 +705,12 @@
           "functionCall": true,
           "reasoning": { "supported": true, "default": true },
           "attachment": true,
-          "temperature": true,
+          "temperature": false,
           "toolCall": true,
           "structuredOutput": true,
           "knowledge": "2025-01",
           "releaseDate": "2026-04-21",
-          "lastUpdated": "2026-04-21",
+          "lastUpdated": "2026-08-31",
           "openWeights": true,
           "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
           "cost": { "input": 0.95, "output": 4, "cacheRead": 0.16 },
@@ -790,11 +722,18 @@
               "interleaved": true,
               "summaries": true,
               "visibility": "summary",
-              "continuation": ["thinking_blocks"]
+              "continuation": ["thinking_blocks"],
+              "notes": ["Temperature is fixed at 1.0 with thinking enabled and 0.6 with thinking disabled."]
             }
           },
-          "metadata": { "selection": ["latest", "coding", "agentic"], "lifecycle": "active" },
-          "selectionRank": 3
+          "metadata": {
+            "selection": ["multimodal", "coding", "optional-thinking"],
+            "lifecycle": "active"
+          },
+          "selectionRank": 4,
+          "reasoningOptions": [
+            { "type": "toggle" }
+          ]
         },
         {
           "id": "kimi-k2.5",
@@ -811,7 +750,7 @@
           "structuredOutput": true,
           "knowledge": "2025-01",
           "releaseDate": "2026-01-27",
-          "lastUpdated": "2026-01-27",
+          "lastUpdated": "2026-08-31",
           "openWeights": true,
           "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
           "cost": { "input": 0.6, "output": 3, "cacheRead": 0.1 },
@@ -823,83 +762,21 @@
               "interleaved": true,
               "summaries": true,
               "visibility": "summary",
-              "continuation": ["thinking_blocks"]
+              "continuation": ["thinking_blocks"],
+              "notes": ["Temperature is fixed at 1.0 with thinking enabled and 0.6 with thinking disabled."]
             }
           },
-          "metadata": { "selection": ["multimodal", "reasoning", "coding"], "lifecycle": "active" },
-          "selectionRank": 4
-        },
-        {
-          "id": "kimi-k2-thinking",
-          "name": "Kimi K2 Thinking",
-          "family": "kimi-thinking",
-          "contextLength": 262144,
-          "maxTokens": 262144,
-          "vision": false,
-          "functionCall": true,
-          "reasoning": { "supported": true, "default": true },
-          "attachment": false,
-          "temperature": true,
-          "toolCall": true,
-          "structuredOutput": true,
-          "knowledge": "2024-08",
-          "releaseDate": "2025-11-06",
-          "lastUpdated": "2025-11-06",
-          "openWeights": true,
-          "modalities": { "input": ["text"], "output": ["text"] },
-          "cost": { "input": 0.6, "output": 2.5, "cacheRead": 0.15 },
-          "interleaved": { "field": "reasoning_content" },
-          "extraCapabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": true,
-              "interleaved": true,
-              "summaries": true,
-              "visibility": "summary",
-              "continuation": ["thinking_blocks"]
-            }
+          "metadata": {
+            "selection": ["compatibility", "multimodal", "reasoning", "coding"],
+            "lifecycle": "legacy",
+            "apiStatus": "sunset-scheduled",
+            "officialSunsetDate": "2026-08-31",
+            "notes": ["Retained for third-party metadata fallback. Kimi schedules full official API retirement for August 31, 2026; inclusion does not imply official availability. Pricing is historical."]
           },
-          "metadata": { "selection": ["deep-reasoning", "multi-step-tools"], "lifecycle": "active" },
-          "selectionRank": 5
-        },
-        {
-          "id": "kimi-k3",
-          "name": "Kimi K3",
-          "family": "kimi-k3",
-          "contextLength": 1048576,
-          "maxTokens": 131072,
-          "vision": true,
-          "functionCall": true,
-          "reasoning": { "supported": true, "default": true },
-          "attachment": true,
-          "temperature": false,
-          "toolCall": true,
-          "structuredOutput": true,
+          "selectionRank": 5,
           "reasoningOptions": [
-            { "type": "toggle" },
-            { "type": "effort", "values": ["low", "high", "max"] }
-          ],
-          "releaseDate": "2026-07-16",
-          "lastUpdated": "2026-07-16",
-          "openWeights": true,
-          "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
-          "cost": { "input": 3, "output": 15, "cacheRead": 0.3 },
-          "interleaved": { "field": "reasoning_content" },
-          "extraCapabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": true,
-              "mode": "effort",
-              "effort": "high",
-              "effort_options": ["low", "high", "max"],
-              "interleaved": true,
-              "summaries": true,
-              "visibility": "summary",
-              "continuation": ["thinking_blocks"]
-            }
-          },
-          "metadata": { "selection": ["latest", "multimodal", "long-context", "agentic"], "lifecycle": "active" },
-          "selectionRank": 1
+            { "type": "toggle" }
+          ]
         }
       ]
     },
@@ -909,10 +786,10 @@
       "apiUrl": "https://api.deepseek.com/models",
       "apiKeyEnv": "DEEPSEEK_API_KEY",
       "docs": [
-        "https://api-docs.deepseek.com/zh-cn/quick_start/pricing",
-        "https://api-docs.deepseek.com/zh-cn/api/create-chat-completion",
-        "https://api-docs.deepseek.com/zh-cn/guides/thinking_mode",
-        "https://api-docs.deepseek.com/news/news260424/"
+        "https://api-docs.deepseek.com/quick_start/pricing/",
+        "https://api-docs.deepseek.com/api/create-chat-completion",
+        "https://api-docs.deepseek.com/guides/thinking_mode/",
+        "https://api-docs.deepseek.com/updates/"
       ],
       "models": [
         {
@@ -937,9 +814,14 @@
           "lastUpdated": "2026-07-31",
           "openWeights": true,
           "modalities": { "input": ["text"], "output": ["text"] },
-          "cost": { "input": 0.14, "output": 0.28, "reasoning": 0.28, "cacheRead": 0.0028 },
+          "cost": { "input": 0.44, "output": 1.32, "reasoning": 1.32, "cacheRead": 0.014 },
           "interleaved": { "field": "reasoning_content" },
-          "metadata": { "selection": ["latest", "cost-efficient", "long-context"], "lifecycle": "active" },
+          "metadata": {
+            "selection": ["latest", "cost-efficient", "long-context"],
+            "lifecycle": "active",
+            "pricingBasis": "peak",
+            "notes": ["USD per million tokens at peak hours; official off-peak prices are half these rates.", "Temperature is effective only with thinking disabled; thinking mode ignores sampling parameters."]
+          },
           "selectionRank": 1
         },
         {
@@ -965,9 +847,14 @@
           "openWeights": true,
           "experimental": true,
           "modalities": { "input": ["text", "image"], "output": ["text"] },
-          "cost": { "input": 0.14, "output": 0.28, "reasoning": 0.28, "cacheRead": 0.0028 },
+          "cost": { "input": 0.44, "output": 1.32, "reasoning": 1.32, "cacheRead": 0.014 },
           "interleaved": { "field": "reasoning_content" },
-          "metadata": { "selection": ["latest", "multimodal", "cost-efficient", "long-context"], "lifecycle": "preview" },
+          "metadata": {
+            "selection": ["latest", "multimodal", "cost-efficient", "long-context"],
+            "lifecycle": "preview",
+            "pricingBasis": "peak",
+            "notes": ["USD per million tokens at peak hours; official off-peak prices are half these rates.", "Temperature is effective only with thinking disabled; thinking mode ignores sampling parameters."]
+          },
           "selectionRank": 2
         },
         {
@@ -985,16 +872,21 @@
           "structuredOutput": true,
           "reasoningOptions": [
             { "type": "toggle" },
-            { "type": "effort", "values": ["high", "max"] }
+            { "type": "effort", "values": ["low", "high", "max"] }
           ],
           "knowledge": "2025-05",
           "releaseDate": "2026-04-24",
-          "lastUpdated": "2026-04-24",
+          "lastUpdated": "2026-08-13",
           "openWeights": true,
           "modalities": { "input": ["text"], "output": ["text"] },
-          "cost": { "input": 0.435, "output": 0.87, "reasoning": 0.87, "cacheRead": 0.003625 },
+          "cost": { "input": 1.32, "output": 3.96, "reasoning": 3.96, "cacheRead": 0.044 },
           "interleaved": { "field": "reasoning_content" },
-          "metadata": { "selection": ["latest", "frontier", "long-context"], "lifecycle": "active" },
+          "metadata": {
+            "selection": ["latest", "frontier", "long-context"],
+            "lifecycle": "active",
+            "pricingBasis": "peak",
+            "notes": ["USD per million tokens at peak hours; official off-peak prices are half these rates.", "Temperature is effective only with thinking disabled; thinking mode ignores sampling parameters."]
+          },
           "selectionRank": 3
         }
       ]
@@ -1003,14 +895,97 @@
       "id": "zhipu",
       "displayName": "Zhipu",
       "docs": [
+        "https://docs.z.ai/guides/llm/glm-5.3",
+        "https://docs.z.ai/guides/vlm/glm-5.3-flash",
         "https://docs.z.ai/guides/llm/glm-5.2",
-        "https://docs.z.ai/guides/llm/glm-5.1",
-        "https://docs.z.ai/guides/overview/pricing",
-        "https://docs.bigmodel.cn/cn/guide/start/model-overview",
-        "https://docs.bigmodel.cn/cn/guide/start/migrate-to-glm-new",
-        "https://docs.bigmodel.cn/cn/guide/capabilities/thinking"
+        "https://docs.z.ai/guides/capabilities/thinking-mode",
+        "https://docs.z.ai/guides/overview/pricing"
       ],
       "models": [
+        {
+          "id": "glm-5.3",
+          "name": "GLM-5.3",
+          "family": "glm",
+          "contextLength": 1000000,
+          "maxTokens": 131072,
+          "vision": false,
+          "functionCall": true,
+          "reasoning": { "supported": true, "default": true },
+          "attachment": false,
+          "temperature": true,
+          "toolCall": true,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-31",
+          "openWeights": true,
+          "modalities": { "input": ["text"], "output": ["text"] },
+          "cost": { "input": 1.4, "output": 4.4, "cacheRead": 0.26 },
+          "interleaved": { "field": "reasoning_content" },
+          "extraCapabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "effort",
+              "effort": "max",
+              "effort_options": ["low", "high", "max"],
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": ["thinking_blocks"],
+              "notes": ["Thinking cannot be disabled; reasoning_effort defaults to max. Set thinking.clear_thinking to false to preserve reasoning across turns."]
+            }
+          },
+          "metadata": {
+            "selection": ["latest", "coding", "long-context", "reasoning"],
+            "lifecycle": "active"
+          },
+          "selectionRank": 1,
+          "reasoningOptions": [
+            { "type": "effort", "values": ["low", "high", "max"] }
+          ]
+        },
+        {
+          "id": "glm-5.3-flash",
+          "name": "GLM-5.3 Flash",
+          "family": "glm",
+          "contextLength": 1000000,
+          "maxTokens": 131072,
+          "vision": true,
+          "functionCall": true,
+          "reasoning": { "supported": true, "default": true },
+          "attachment": true,
+          "temperature": true,
+          "toolCall": true,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-31",
+          "openWeights": true,
+          "modalities": { "input": ["text", "image", "video", "file"], "output": ["text"] },
+          "cost": { "input": 0.075, "output": 0.25, "cacheRead": 0.015 },
+          "interleaved": { "field": "reasoning_content" },
+          "extraCapabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "effort",
+              "effort": "max",
+              "effort_options": ["low", "high", "max"],
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": ["thinking_blocks"],
+              "notes": ["Thinking cannot be disabled; reasoning_effort defaults to max. Set thinking.clear_thinking to false to preserve reasoning across turns."]
+            }
+          },
+          "metadata": {
+            "selection": ["latest", "multimodal", "coding", "cost-efficient"],
+            "lifecycle": "active",
+            "pricingBasis": "promotional",
+            "pricingValidUntil": "2026-09-10T00:00:00+08:00"
+          },
+          "selectionRank": 2,
+          "reasoningOptions": [
+            { "type": "effort", "values": ["low", "high", "max"] }
+          ]
+        },
         {
           "id": "glm-5.2",
           "name": "GLM-5.2",
@@ -1043,137 +1018,15 @@
               "continuation": ["thinking_blocks"]
             }
           },
-          "metadata": { "selection": ["latest", "coding", "long-context", "reasoning"], "lifecycle": "active" },
-          "selectionRank": 1
-        },
-        {
-          "id": "glm-5.1",
-          "name": "GLM-5.1",
-          "family": "glm",
-          "contextLength": 200000,
-          "maxTokens": 131072,
-          "vision": false,
-          "functionCall": true,
-          "reasoning": { "supported": true, "default": true },
-          "attachment": false,
-          "temperature": true,
-          "toolCall": true,
-          "structuredOutput": true,
-          "releaseDate": "2026-03-27",
-          "lastUpdated": "2026-03-27",
-          "openWeights": false,
-          "modalities": { "input": ["text"], "output": ["text"] },
-          "cost": { "input": 1.4, "output": 4.4, "cacheRead": 0.26, "cacheWrite": 0 },
-          "interleaved": { "field": "reasoning_content" },
-          "extraCapabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": true,
-              "interleaved": true,
-              "summaries": true,
-              "visibility": "summary",
-              "continuation": ["thinking_blocks"]
-            }
+          "metadata": {
+            "selection": ["coding", "long-context", "optional-thinking"],
+            "lifecycle": "active"
           },
-          "metadata": { "selection": ["latest", "coding", "long-horizon"], "lifecycle": "active" },
-          "selectionRank": 2
-        },
-        {
-          "id": "glm-5",
-          "name": "GLM-5",
-          "family": "glm",
-          "contextLength": 204800,
-          "maxTokens": 131072,
-          "vision": false,
-          "functionCall": true,
-          "reasoning": { "supported": true, "default": true },
-          "attachment": false,
-          "temperature": true,
-          "toolCall": true,
-          "structuredOutput": true,
-          "releaseDate": "2026-02-11",
-          "lastUpdated": "2026-02-11",
-          "openWeights": true,
-          "modalities": { "input": ["text"], "output": ["text"] },
-          "cost": { "input": 1, "output": 3.2, "cacheRead": 0.2, "cacheWrite": 0 },
-          "interleaved": { "field": "reasoning_content" },
-          "extraCapabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": true,
-              "interleaved": true,
-              "summaries": true,
-              "visibility": "summary",
-              "continuation": ["thinking_blocks"]
-            }
-          },
-          "metadata": { "selection": ["coding", "agentic", "reasoning"], "lifecycle": "active" },
-          "selectionRank": 3
-        },
-        {
-          "id": "glm-5v-turbo",
-          "name": "GLM-5V-Turbo",
-          "family": "glm",
-          "contextLength": 200000,
-          "maxTokens": 131072,
-          "vision": true,
-          "functionCall": true,
-          "reasoning": { "supported": true, "default": true },
-          "attachment": true,
-          "temperature": true,
-          "toolCall": true,
-          "structuredOutput": true,
-          "releaseDate": "2026-04-01",
-          "lastUpdated": "2026-04-01",
-          "openWeights": false,
-          "modalities": { "input": ["text", "image", "video", "pdf"], "output": ["text"] },
-          "cost": { "input": 5, "output": 22, "cacheRead": 1.2, "cacheWrite": 0 },
-          "interleaved": { "field": "reasoning_content" },
-          "extraCapabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": true,
-              "interleaved": true,
-              "summaries": true,
-              "visibility": "summary",
-              "continuation": ["thinking_blocks"]
-            }
-          },
-          "metadata": { "selection": ["vision", "coding", "reasoning"], "lifecycle": "active" },
-          "selectionRank": 4
-        },
-        {
-          "id": "glm-4.7",
-          "name": "GLM-4.7",
-          "family": "glm",
-          "contextLength": 204800,
-          "maxTokens": 131072,
-          "vision": false,
-          "functionCall": true,
-          "reasoning": { "supported": true, "default": true },
-          "attachment": false,
-          "temperature": true,
-          "toolCall": true,
-          "structuredOutput": true,
-          "knowledge": "2025-04",
-          "releaseDate": "2025-12-22",
-          "lastUpdated": "2025-12-22",
-          "openWeights": true,
-          "modalities": { "input": ["text"], "output": ["text"] },
-          "cost": { "input": 0.6, "output": 2.2, "cacheRead": 0.11, "cacheWrite": 0 },
-          "interleaved": { "field": "reasoning_content" },
-          "extraCapabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": true,
-              "interleaved": true,
-              "summaries": true,
-              "visibility": "summary",
-              "continuation": ["thinking_blocks"]
-            }
-          },
-          "metadata": { "selection": ["open-weight", "coding", "reasoning"], "lifecycle": "active" },
-          "selectionRank": 5
+          "selectionRank": 3,
+          "reasoningOptions": [
+            { "type": "toggle" },
+            { "type": "effort", "values": ["high", "max"] }
+          ]
         }
       ]
     },
@@ -1272,60 +1125,364 @@
           },
           "metadata": { "selection": ["latest", "fast", "coding"], "lifecycle": "active" },
           "selectionRank": 3
+        }
+      ]
+    },
+    {
+      "id": "stepfun",
+      "displayName": "StepFun",
+      "docs": [
+        "https://platform.stepfun.ai/docs/en/guides/models/step-3.7-flash",
+        "https://platform.stepfun.ai/docs/en/guides/models/step-3.5-flash",
+        "https://platform.stepfun.ai/docs/en/api-reference/chat/chat-completion-create",
+        "https://platform.stepfun.ai/docs/en/guides/developer/reasoning",
+        "https://platform.stepfun.ai/docs/en/guides/pricing/details",
+        "https://huggingface.co/stepfun-ai/Step-3.7-Flash"
+      ],
+      "models": [
+        {
+          "id": "step-3.7-flash",
+          "name": "Step 3.7 Flash",
+          "family": "step",
+          "contextLength": 262144,
+          "maxTokens": 262144,
+          "vision": true,
+          "functionCall": true,
+          "reasoning": { "supported": true, "default": true },
+          "attachment": true,
+          "temperature": true,
+          "toolCall": true,
+          "structuredOutput": true,
+          "reasoningOptions": [
+            { "type": "effort", "values": ["low", "medium", "high"] }
+          ],
+          "lastUpdated": "2026-08-31",
+          "openWeights": true,
+          "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
+          "cost": { "input": 0.2, "output": 1.15, "cacheRead": 0.04 },
+          "extraCapabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "effort",
+              "effort": "medium",
+              "effort_options": ["low", "medium", "high"],
+              "notes": ["The API returns reasoning by default; reasoning_format=deepseek-style switches the response field to reasoning_content."]
+            }
+          },
+          "metadata": {
+            "selection": ["latest", "multimodal", "coding", "reasoning"],
+            "lifecycle": "active",
+            "notes": ["max_tokens is bounded by the shared input/output context window. Structured output support refers to JSON mode."]
+          },
+          "selectionRank": 1
         },
         {
-          "id": "MiniMax-M2.5",
-          "name": "MiniMax-M2.5",
-          "family": "minimax",
-          "contextLength": 204800,
-          "maxTokens": 131072,
+          "id": "step-3.5-flash-2603",
+          "name": "Step 3.5 Flash 2603",
+          "family": "step",
+          "contextLength": 262144,
+          "maxTokens": 262144,
           "vision": false,
           "functionCall": true,
           "reasoning": { "supported": true, "default": true },
           "attachment": false,
           "temperature": true,
           "toolCall": true,
-          "structuredOutput": false,
-          "releaseDate": "2026-02-12",
-          "lastUpdated": "2026-02-12",
-          "openWeights": true,
+          "structuredOutput": true,
+          "reasoningOptions": [
+            { "type": "effort", "values": ["low", "high"] }
+          ],
+          "lastUpdated": "2026-08-31",
           "modalities": { "input": ["text"], "output": ["text"] },
-          "cost": { "input": 0.3, "output": 1.2, "cacheRead": 0.03, "cacheWrite": 0.375 },
+          "cost": { "input": 0.1, "output": 0.3, "cacheRead": 0.02 },
           "extraCapabilities": {
             "reasoning": {
               "supported": true,
-              "default_enabled": true
+              "default_enabled": true,
+              "mode": "effort",
+              "effort_options": ["low", "high"],
+              "notes": ["The API returns reasoning by default; reasoning_format=deepseek-style switches the response field to reasoning_content."]
             }
           },
-          "metadata": { "selection": ["coding", "value", "tool-use"], "lifecycle": "active" },
+          "metadata": {
+            "selection": ["coding", "reasoning", "cost-efficient"],
+            "lifecycle": "active",
+            "notes": ["max_tokens is bounded by the shared input/output context window. Structured output support refers to JSON mode."]
+          },
+          "selectionRank": 2
+        },
+        {
+          "id": "step-3.5-flash",
+          "name": "Step 3.5 Flash",
+          "family": "step",
+          "contextLength": 262144,
+          "maxTokens": 262144,
+          "vision": false,
+          "functionCall": true,
+          "reasoning": { "supported": true, "default": true },
+          "attachment": false,
+          "temperature": true,
+          "toolCall": true,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-31",
+          "modalities": { "input": ["text"], "output": ["text"] },
+          "cost": { "input": 0.1, "output": 0.3, "cacheRead": 0.02 },
+          "extraCapabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "fixed",
+              "notes": ["The API returns reasoning by default; reasoning_format=deepseek-style switches the response field to reasoning_content."]
+            }
+          },
+          "metadata": {
+            "selection": ["coding", "reasoning", "cost-efficient"],
+            "lifecycle": "active",
+            "notes": ["max_tokens is bounded by the shared input/output context window. Structured output support refers to JSON mode."]
+          },
+          "selectionRank": 3
+        }
+      ]
+    },
+    {
+      "id": "qwen",
+      "displayName": "Qwen",
+      "docs": [
+        "https://www.alibabacloud.com/help/en/model-studio/models",
+        "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-8-max",
+        "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-7-plus",
+        "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-8-flash",
+        "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-plus",
+        "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-flash",
+        "https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen3-coder-next",
+        "https://www.alibabacloud.com/help/en/model-studio/deep-thinking",
+        "https://www.alibabacloud.com/help/en/model-studio/qwen-function-calling",
+        "https://huggingface.co/Qwen/Qwen3-Coder-Next"
+      ],
+      "models": [
+        {
+          "id": "qwen3.8-max",
+          "name": "Qwen3.8 Max",
+          "family": "qwen",
+          "contextLength": 1000000,
+          "maxTokens": 131072,
+          "vision": true,
+          "functionCall": true,
+          "reasoning": { "supported": true, "default": true },
+          "attachment": true,
+          "temperature": true,
+          "toolCall": true,
+          "structuredOutput": true,
+          "reasoningOptions": [
+            { "type": "toggle" },
+            { "type": "budget" }
+          ],
+          "lastUpdated": "2026-08-31",
+          "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
+          "cost": { "input": 2, "output": 6, "cacheRead": 0.17, "cacheWrite": 2.5 },
+          "interleaved": { "field": "reasoning_content" },
+          "extraCapabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "budget",
+              "budget": {
+                "max": 262144,
+                "default": 262144,
+                "unit": "tokens"
+              },
+              "interleaved": true,
+              "notes": ["enable_thinking toggles reasoning; thinking_budget caps it. Set preserve_thinking=true to retain reasoning_content across turns."]
+            }
+          },
+          "metadata": {
+            "selection": ["multimodal", "reasoning", "coding"],
+            "lifecycle": "active",
+            "pricingRegion": "Singapore",
+            "pricingScope": "International",
+            "pricingBasis": "standard",
+            "notes": ["Thinking mode has a 983616-token input limit and a separate 262144-token reasoning budget.", "Cache prices refer to explicit caching. Longer inputs may use higher pricing tiers."]
+          },
+          "selectionRank": 1
+        },
+        {
+          "id": "qwen3.7-plus",
+          "name": "Qwen3.7 Plus",
+          "family": "qwen",
+          "contextLength": 1000000,
+          "maxTokens": 131072,
+          "vision": true,
+          "functionCall": true,
+          "reasoning": { "supported": true, "default": true },
+          "attachment": true,
+          "temperature": true,
+          "toolCall": true,
+          "structuredOutput": true,
+          "reasoningOptions": [
+            { "type": "toggle" },
+            { "type": "budget" }
+          ],
+          "lastUpdated": "2026-08-31",
+          "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
+          "cost": { "input": 0.4, "output": 1.6, "cacheRead": 0.04, "cacheWrite": 0.5 },
+          "interleaved": { "field": "reasoning_content" },
+          "extraCapabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "budget",
+              "budget": {
+                "max": 262144,
+                "default": 262144,
+                "unit": "tokens"
+              },
+              "interleaved": true,
+              "notes": ["enable_thinking toggles reasoning; thinking_budget caps it. Set preserve_thinking=true to retain reasoning_content across turns."]
+            }
+          },
+          "metadata": {
+            "selection": ["multimodal", "reasoning", "coding"],
+            "lifecycle": "active",
+            "pricingRegion": "Singapore",
+            "pricingScope": "International",
+            "pricingBasis": "input-up-to-256k",
+            "notes": ["Thinking mode has a 983616-token input limit and a separate 262144-token reasoning budget.", "Cache prices refer to explicit caching. Longer inputs may use higher pricing tiers."]
+          },
+          "selectionRank": 2
+        },
+        {
+          "id": "qwen3.8-flash",
+          "name": "Qwen3.8 Flash",
+          "family": "qwen",
+          "contextLength": 1000000,
+          "maxTokens": 131072,
+          "vision": true,
+          "functionCall": true,
+          "reasoning": { "supported": true, "default": true },
+          "attachment": true,
+          "temperature": true,
+          "toolCall": true,
+          "structuredOutput": true,
+          "reasoningOptions": [
+            { "type": "toggle" },
+            { "type": "budget" }
+          ],
+          "lastUpdated": "2026-08-31",
+          "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
+          "cost": { "input": 0.15, "output": 0.47, "cacheRead": 0.016, "cacheWrite": 0.2 },
+          "interleaved": { "field": "reasoning_content" },
+          "extraCapabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "budget",
+              "budget": {
+                "max": 262144,
+                "default": 262144,
+                "unit": "tokens"
+              },
+              "interleaved": true,
+              "notes": ["enable_thinking toggles reasoning; thinking_budget caps it. Set preserve_thinking=true to retain reasoning_content across turns."]
+            }
+          },
+          "metadata": {
+            "selection": ["multimodal", "reasoning", "coding"],
+            "lifecycle": "active",
+            "pricingRegion": "Singapore",
+            "pricingScope": "International",
+            "pricingBasis": "standard",
+            "notes": ["Thinking mode has a 983616-token input limit and a separate 262144-token reasoning budget.", "Cache prices refer to explicit caching. Longer inputs may use higher pricing tiers."]
+          },
+          "selectionRank": 3
+        },
+        {
+          "id": "qwen3-coder-plus",
+          "name": "Qwen3 Coder Plus",
+          "family": "qwen-coder",
+          "contextLength": 1000000,
+          "maxTokens": 65536,
+          "vision": false,
+          "functionCall": true,
+          "reasoning": { "supported": false, "default": false },
+          "attachment": false,
+          "temperature": true,
+          "toolCall": true,
+          "structuredOutput": false,
+          "lastUpdated": "2026-08-31",
+          "modalities": { "input": ["text"], "output": ["text"] },
+          "cost": { "input": 1, "output": 5, "cacheRead": 0.1, "cacheWrite": 1.25 },
+          "extraCapabilities": {
+            "reasoning": { "supported": false, "default_enabled": false }
+          },
+          "metadata": {
+            "selection": ["coding", "agentic"],
+            "lifecycle": "active",
+            "pricingRegion": "Singapore",
+            "pricingScope": "International",
+            "pricingBasis": "input-up-to-32k",
+            "notes": ["Tool support follows the Qwen function-calling guide; hosted model cards list regional restrictions. Coder models do not expose thinking controls.", "Cache prices, when present, refer to explicit caching. Longer inputs may use higher pricing tiers."]
+          },
           "selectionRank": 4
         },
         {
-          "id": "MiniMax-M2.5-highspeed",
-          "name": "MiniMax-M2.5-highspeed",
-          "family": "minimax",
-          "contextLength": 204800,
-          "maxTokens": 131072,
+          "id": "qwen3-coder-flash",
+          "name": "Qwen3 Coder Flash",
+          "family": "qwen-coder",
+          "contextLength": 1000000,
+          "maxTokens": 65536,
           "vision": false,
           "functionCall": true,
-          "reasoning": { "supported": true, "default": true },
+          "reasoning": { "supported": false, "default": false },
           "attachment": false,
           "temperature": true,
           "toolCall": true,
           "structuredOutput": false,
-          "releaseDate": "2026-02-13",
-          "lastUpdated": "2026-02-13",
+          "lastUpdated": "2026-08-31",
+          "modalities": { "input": ["text"], "output": ["text"] },
+          "cost": { "input": 0.3, "output": 1.5, "cacheRead": 0.03, "cacheWrite": 0.375 },
+          "extraCapabilities": {
+            "reasoning": { "supported": false, "default_enabled": false }
+          },
+          "metadata": {
+            "selection": ["coding", "agentic"],
+            "lifecycle": "active",
+            "pricingRegion": "Singapore",
+            "pricingScope": "International",
+            "pricingBasis": "input-up-to-32k",
+            "notes": ["Tool support follows the Qwen function-calling guide; hosted model cards list regional restrictions. Coder models do not expose thinking controls.", "Cache prices, when present, refer to explicit caching. Longer inputs may use higher pricing tiers."]
+          },
+          "selectionRank": 5
+        },
+        {
+          "id": "qwen3-coder-next",
+          "name": "Qwen3 Coder Next",
+          "family": "qwen-coder",
+          "contextLength": 262144,
+          "maxTokens": 65536,
+          "vision": false,
+          "functionCall": true,
+          "reasoning": { "supported": false, "default": false },
+          "attachment": false,
+          "temperature": true,
+          "toolCall": true,
+          "structuredOutput": false,
+          "lastUpdated": "2026-08-31",
           "openWeights": true,
           "modalities": { "input": ["text"], "output": ["text"] },
-          "cost": { "input": 0.6, "output": 2.4, "cacheRead": 0.06, "cacheWrite": 0.375 },
+          "cost": { "input": 0.3, "output": 1.5 },
           "extraCapabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": true
-            }
+            "reasoning": { "supported": false, "default_enabled": false }
           },
-          "metadata": { "selection": ["fast", "coding", "tool-use"], "lifecycle": "active" },
-          "selectionRank": 5
+          "metadata": {
+            "selection": ["coding", "agentic"],
+            "lifecycle": "active",
+            "pricingRegion": "Singapore",
+            "pricingScope": "International",
+            "pricingBasis": "input-up-to-32k",
+            "notes": ["Tool support follows the Qwen function-calling guide; hosted model cards list regional restrictions. Coder models do not expose thinking controls.", "Cache prices, when present, refer to explicit caching. Longer inputs may use higher pricing tiers."]
+          },
+          "selectionRank": 6
         }
       ]
     }

--- a/src/discovery/adapters/BaseModelsAdapter.ts
+++ b/src/discovery/adapters/BaseModelsAdapter.ts
@@ -130,7 +130,7 @@ function sortSeeds(seeds: CustomProviderModelSeed[]): CustomProviderModelSeed[] 
   });
 }
 
-export abstract class SeededModelsAdapter implements ModelsAdapter {
+export class SeededModelsAdapter implements ModelsAdapter {
   constructor(protected readonly source: CustomProviderSourceSeed) {}
 
   sourceId(): CustomProviderSourceSeed['id'] {

--- a/src/discovery/synthesizeCustomProvider.test.ts
+++ b/src/discovery/synthesizeCustomProvider.test.ts
@@ -52,22 +52,40 @@ test('uses official doc-derived seeds when API keys are missing', async () => {
     const result = await synthesizeCustomProvider();
 
     assert.equal(result.models.length, result.catalog.maxModels);
+    assert.equal(result.models.length, 37);
+    assert.deepEqual(
+      new Set(result.models.map(model => model.id)),
+      new Set(result.catalog.sources.flatMap(source => source.models.map(model => model.id))),
+    );
     assert.deepEqual(
       result.summaries.map(summary => [summary.displayName, summary.selected]),
       [
-        ['OpenAI', 10],
+        ['OpenAI', 5],
         ['Anthropic', 4],
         ['Gemini', 5],
         ['Kimi', 5],
         ['DeepSeek', 3],
-        ['Zhipu', 5],
-        ['MiniMax', 5],
+        ['Zhipu', 3],
+        ['MiniMax', 3],
+        ['StepFun', 3],
+        ['Qwen', 6],
       ],
     );
     assert.equal(
       result.summaries.every(summary => summary.status === 'seed'),
       true,
     );
+    const selectedIds = new Set(result.models.map(model => model.id));
+    for (const id of ['gpt-5.5', 'kimi-k2.5', 'gemini-3.5-flash', 'gemini-3.5-flash-lite']) {
+      assert.ok(selectedIds.has(id), `Missing compatibility model: ${id}`);
+    }
+    for (const id of [
+      'gpt-5.4', 'gpt-5.4-pro', 'gpt-5.4-mini', 'gpt-5.4-nano', 'gpt-5.3-codex',
+      'gemini-2.5-pro', 'kimi-k2-thinking', 'glm-5.1', 'glm-5', 'glm-5v-turbo', 'glm-4.7',
+      'MiniMax-M2.5', 'MiniMax-M2.5-highspeed',
+    ]) {
+      assert.equal(selectedIds.has(id), false, `Retired selection is still present: ${id}`);
+    }
   });
 });
 
@@ -90,7 +108,7 @@ test('creates valid normalized model cards in the provider output shape', async 
     JsonValidator.validateProviderInfo(providerInfo);
 
     const provider = createModelsDevProvider(providerInfo);
-    const model = provider.models.find(item => item.id === 'gpt-5.4');
+    const model = provider.models.find(item => item.id === 'gpt-5.5');
     const gpt55 = provider.models.find(item => item.id === 'gpt-5.5');
     const gpt56 = provider.models.find(item => item.id === 'gpt-5.6');
     const gpt56Sol = provider.models.find(item => item.id === 'gpt-5.6-sol');
@@ -121,9 +139,12 @@ test('creates valid normalized model cards in the provider output shape', async 
     );
     assert.deepEqual(
       seededDeepSeekV4Pro?.extraCapabilities?.reasoning?.effort_options,
-      ['high', 'max'],
+      ['low', 'high', 'max'],
     );
     assert.equal(seededKimiK25?.extraCapabilities?.reasoning?.default_enabled, true);
+    assert.equal(seededKimiK25?.metadata?.lifecycle, 'legacy');
+    assert.equal(seededKimiK25?.metadata?.apiStatus, 'sunset-scheduled');
+    assert.equal(seededKimiK25?.metadata?.officialSunsetDate, '2026-08-31');
 
     applyReasoningPortraits(providerData);
     const miniMaxM27 = provider.models.find(item => item.id === 'MiniMax-M2.7');
@@ -173,10 +194,11 @@ test('creates valid normalized model cards in the provider output shape', async 
     assert.equal(model?.metadata?.sourceProvider, 'openai');
     assert.equal(deepSeekV4?.limit?.context, 1000000);
     assert.equal(deepSeekV4?.limit?.output, 384000);
-    assert.equal(deepSeekV4?.cost?.input, 0.435);
-    assert.equal(deepSeekV4?.cost?.output, 0.87);
-    assert.equal(deepSeekV4?.cost?.reasoning, 0.87);
-    assert.equal(deepSeekV4?.cost?.cache_read, 0.003625);
+    assert.equal(deepSeekV4?.cost?.input, 1.32);
+    assert.equal(deepSeekV4?.cost?.output, 3.96);
+    assert.equal(deepSeekV4?.cost?.reasoning, 3.96);
+    assert.equal(deepSeekV4?.cost?.cache_read, 0.044);
+    assert.equal(deepSeekV4?.metadata?.pricingBasis, 'peak');
     assert.equal(deepSeekV4?.open_weights, true);
     assert.deepEqual(deepSeekV4Flash?.reasoning_options, [
       { type: 'toggle', values: undefined },
@@ -191,7 +213,7 @@ test('creates valid normalized model cards in the provider output shape', async 
     ]);
     assert.deepEqual(deepSeekV4?.reasoning_options, [
       { type: 'toggle', values: undefined },
-      { type: 'effort', values: ['high', 'max'] },
+      { type: 'effort', values: ['low', 'high', 'max'] },
     ]);
     assert.deepEqual(deepSeekV4Flash?.extra_capabilities?.reasoning?.effort_options, [
       'low',
@@ -199,6 +221,7 @@ test('creates valid normalized model cards in the provider output shape', async 
       'max',
     ]);
     assert.deepEqual(deepSeekV4?.extra_capabilities?.reasoning?.effort_options, [
+      'low',
       'high',
       'max',
     ]);
@@ -206,13 +229,93 @@ test('creates valid normalized model cards in the provider output shape', async 
     assert.ok(claudeOpus5);
     assert.ok(gemini36Flash);
     assert.equal(kimiK3?.limit?.context, 1048576);
-    assert.equal(kimiK3?.limit?.output, 131072);
+    assert.equal(kimiK3?.limit?.output, 1048576);
+    assert.equal(kimiK3?.extra_capabilities?.reasoning?.effort, 'max');
+    assert.deepEqual(kimiK3?.reasoning_options, [
+      { type: 'effort', values: ['low', 'high', 'max'] },
+    ]);
     assert.equal(glm52?.limit?.context, 1000000);
     assert.equal(glm52?.limit?.output, 131072);
     assert.equal(glm52?.extra_capabilities?.reasoning?.effort_options?.includes('max'), true);
     assert.equal(miniMaxM3?.limit?.context, 1000000);
     assert.equal(miniMaxM3?.limit?.output, 128000);
     assert.equal(miniMaxM27?.extra_capabilities?.reasoning?.interleaved, true);
+  });
+});
+
+test('preserves model-specific controls and modalities through normalization and portraits', async () => {
+  await withoutApiKeys(async () => {
+    const result = await synthesizeCustomProvider();
+    const provider = createModelsDevProvider(createProviderInfo(
+      'custom-provider', 'custom provider', result.models,
+    ));
+    applyReasoningPortraits({ providers: { [provider.id]: provider } });
+    const getModel = (id: string) => {
+      const model = provider.models.find(item => item.id === id);
+      assert.ok(model, `Missing selected model: ${id}`);
+      return model;
+    };
+
+    const gemini37 = getModel('gemini-3.7-flash');
+    assert.equal(gemini37.extra_capabilities?.reasoning?.level, 'medium');
+    assert.deepEqual(gemini37.extra_capabilities?.reasoning?.level_options, ['low', 'medium', 'high']);
+    assert.deepEqual(gemini37.reasoning_options, [{ type: 'effort', values: ['low', 'medium', 'high'] }]);
+    assert.ok(getModel('gemini-3.6-flash').extra_capabilities?.reasoning?.level_options?.includes('minimal'));
+
+    const kimiCode = getModel('kimi-k2.7-code');
+    const kimiHighspeed = getModel('kimi-k2.7-code-highspeed');
+    for (const model of [kimiCode, kimiHighspeed]) {
+      assert.equal(model.temperature, false);
+      assert.equal(model.extra_capabilities?.reasoning?.mode, 'fixed');
+      assert.equal(model.reasoning_options?.some(option => option.type === 'toggle') ?? false, false);
+      assert.deepEqual(model.modalities?.input, ['text', 'image', 'video']);
+    }
+    assert.equal(kimiCode.cost?.input, 0.95);
+    assert.equal(kimiHighspeed.cost?.input, 1.9);
+    assert.equal(kimiCode.cost?.output, 4);
+    assert.equal(kimiHighspeed.cost?.output, 8);
+    assert.equal(getModel('kimi-k2.6').reasoning_options?.[0].type, 'toggle');
+
+    for (const id of ['glm-5.3', 'glm-5.3-flash']) {
+      const model = getModel(id);
+      assert.equal(model.limit?.context, 1000000);
+      assert.equal(model.limit?.output, 131072);
+      assert.equal(model.extra_capabilities?.reasoning?.effort, 'max');
+      assert.deepEqual(model.reasoning_options, [{ type: 'effort', values: ['low', 'high', 'max'] }]);
+    }
+    assert.equal(getModel('glm-5.3').vision, false);
+    assert.equal(getModel('glm-5.3-flash').vision, true);
+    assert.equal(getModel('glm-5.2').reasoning_options?.[0].type, 'toggle');
+
+    const step37 = getModel('step-3.7-flash');
+    const step35 = getModel('step-3.5-flash');
+    const step35March = getModel('step-3.5-flash-2603');
+    assert.deepEqual(step37.modalities?.input, ['text', 'image', 'video']);
+    assert.equal(step37.extra_capabilities?.reasoning?.effort, 'medium');
+    assert.deepEqual(step37.reasoning_options, [{ type: 'effort', values: ['low', 'medium', 'high'] }]);
+    assert.deepEqual(step35March.reasoning_options, [{ type: 'effort', values: ['low', 'high'] }]);
+    assert.equal(step35.reasoning_options, undefined);
+    assert.equal(step35.vision, false);
+
+    for (const id of ['qwen3.8-max', 'qwen3.7-plus', 'qwen3.8-flash']) {
+      const model = getModel(id);
+      assert.equal(model.limit?.context, 1000000);
+      assert.equal(model.limit?.output, 131072);
+      assert.equal(model.vision, true);
+      assert.equal(model.extra_capabilities?.reasoning?.mode, 'budget');
+      assert.equal(model.extra_capabilities?.reasoning?.budget?.max, 262144);
+      assert.deepEqual(model.reasoning_options?.map(option => option.type), ['toggle', 'budget']);
+    }
+    for (const id of ['qwen3-coder-plus', 'qwen3-coder-flash', 'qwen3-coder-next']) {
+      const model = getModel(id);
+      assert.equal(model.vision, false);
+      assert.deepEqual(model.reasoning, { supported: false });
+      assert.equal(model.extra_capabilities?.reasoning?.supported, false);
+      assert.equal(model.reasoning_options, undefined);
+      assert.equal(model.tool_call, true);
+      assert.equal(model.limit?.output, 65536);
+    }
+    assert.equal(getModel('qwen3-coder-next').limit?.context, 262144);
   });
 });
 

--- a/src/discovery/synthesizeCustomProvider.ts
+++ b/src/discovery/synthesizeCustomProvider.ts
@@ -14,6 +14,7 @@ import { KimiModelsAdapter } from './adapters/KimiModelsAdapter';
 import { DeepSeekModelsAdapter } from './adapters/DeepSeekModelsAdapter';
 import { ZhipuModelsAdapter } from './adapters/ZhipuModelsAdapter';
 import { MiniMaxModelsAdapter } from './adapters/MiniMaxModelsAdapter';
+import { SeededModelsAdapter } from './adapters/BaseModelsAdapter';
 
 export interface SynthesizeCustomProviderOptions {
   seedFilePath?: string;
@@ -38,6 +39,9 @@ function createAdapters(catalog: CustomProviderSeedCatalog): ModelsAdapter[] {
         return new ZhipuModelsAdapter(source);
       case 'minimax':
         return new MiniMaxModelsAdapter(source);
+      case 'stepfun':
+      case 'qwen':
+        return new SeededModelsAdapter(source);
       default:
         throw new Error(`Unsupported custom provider source: ${source.id}`);
     }

--- a/src/discovery/types.ts
+++ b/src/discovery/types.ts
@@ -8,7 +8,9 @@ export type CustomProviderSourceId =
   | 'kimi'
   | 'deepseek'
   | 'zhipu'
-  | 'minimax';
+  | 'minimax'
+  | 'stepfun'
+  | 'qwen';
 
 export interface CustomProviderSeedCatalog {
   updatedAt: string;

--- a/src/models/extra-capabilities.test.ts
+++ b/src/models/extra-capabilities.test.ts
@@ -227,43 +227,30 @@ test('matches interleaved reasoning portraits for canonical and slash-prefixed i
   }
 });
 
-test('applies distinct effective effort portraits to DeepSeek V4 models', () => {
-  const cases = [
-    {
-      ids: [
-        'deepseek-v4-flash',
-        'deepseek/deepseek-v4-flash',
-        'deepseek-v4-flash-vision-exp',
-        'deepseek/deepseek-v4-flash-vision-exp',
-      ],
-      effortOptions: ['low', 'high', 'max'],
-      notes: [
-        'The DeepSeek API maps xhigh to high for V4 Flash; effort_options lists distinct model-effective levels.',
-      ],
-    },
-    {
-      ids: ['deepseek-v4-pro', 'deepseek/deepseek-v4-pro'],
-      effortOptions: ['high', 'max'],
-      notes: [
-        'The DeepSeek API maps low to high and xhigh to max for V4 Pro; effort_options lists distinct model-effective levels.',
-      ],
-    },
+test('applies the current effective effort levels to all DeepSeek V4 models', () => {
+  const ids = [
+    'deepseek-v4-flash',
+    'deepseek/deepseek-v4-flash',
+    'deepseek-v4-flash-vision-exp',
+    'deepseek/deepseek-v4-flash-vision-exp',
+    'deepseek-v4-pro',
+    'deepseek/deepseek-v4-pro',
   ];
 
-  for (const { ids, effortOptions, notes } of cases) {
-    for (const id of ids) {
-      assertReasoningPortrait(id, {
-        defaultEnabled: true,
-        mode: 'effort',
-        effort: 'high',
-        effortOptions,
-        interleaved: true,
-        summaries: true,
-        visibility: 'summary',
-        continuation: ['thinking_blocks'],
-        notes,
-      });
-    }
+  for (const id of ids) {
+    assertReasoningPortrait(id, {
+      defaultEnabled: true,
+      mode: 'effort',
+      effort: 'high',
+      effortOptions: ['low', 'high', 'max'],
+      interleaved: true,
+      summaries: true,
+      visibility: 'summary',
+      continuation: ['thinking_blocks'],
+      notes: [
+        'The DeepSeek API maps medium and xhigh to high for V4 models; effort_options lists distinct model-effective levels.',
+      ],
+    });
   }
 });
 
@@ -290,7 +277,7 @@ test('keeps provider-specific DeepSeek effort controls separate from the model p
     { type: 'toggle' },
     { type: 'effort', values: ['high', 'xhigh'] },
   ]);
-  assert.deepEqual(model.extra_capabilities?.reasoning?.effort_options, ['high', 'max']);
+  assert.deepEqual(model.extra_capabilities?.reasoning?.effort_options, ['low', 'high', 'max']);
 });
 
 test('matches Qwen interleaved reasoning portraits', () => {

--- a/src/models/extra-capabilities.ts
+++ b/src/models/extra-capabilities.ts
@@ -407,42 +407,27 @@ const DEFAULT_INTERLEAVED_REASONING_PORTRAIT: ExtraCapabilitiesReasoning = {
   continuation: ['thinking_blocks'],
 };
 
-const DEEPSEEK_V4_COMMON_REASONING_PORTRAIT: ExtraCapabilitiesReasoning = {
+const DEEPSEEK_V4_REASONING_PORTRAIT: ExtraCapabilitiesReasoning = {
   supported: true,
   default_enabled: true,
   mode: 'effort',
   effort: 'high',
+  effort_options: ['low', 'high', 'max'],
   interleaved: true,
   summaries: true,
   visibility: 'summary',
   continuation: ['thinking_blocks'],
-};
-
-const DEEPSEEK_V4_FLASH_REASONING_PORTRAIT: ExtraCapabilitiesReasoning = {
-  ...DEEPSEEK_V4_COMMON_REASONING_PORTRAIT,
-  effort_options: ['low', 'high', 'max'],
   notes: [
-    'The DeepSeek API maps xhigh to high for V4 Flash; effort_options lists distinct model-effective levels.',
-  ],
-};
-
-const DEEPSEEK_V4_PRO_REASONING_PORTRAIT: ExtraCapabilitiesReasoning = {
-  ...DEEPSEEK_V4_COMMON_REASONING_PORTRAIT,
-  effort_options: ['high', 'max'],
-  notes: [
-    'The DeepSeek API maps low to high and xhigh to max for V4 Pro; effort_options lists distinct model-effective levels.',
+    'The DeepSeek API maps medium and xhigh to high for V4 models; effort_options lists distinct model-effective levels.',
   ],
 };
 
 const REASONING_PORTRAITS: ReasoningPortraitDefinition[] = [
   {
     matches: (_normalizedId, baseId) =>
-      baseId === 'deepseek-v4-flash' || baseId === 'deepseek-v4-flash-vision-exp',
-    portrait: DEEPSEEK_V4_FLASH_REASONING_PORTRAIT,
-  },
-  {
-    matches: (_normalizedId, baseId) => baseId === 'deepseek-v4-pro',
-    portrait: DEEPSEEK_V4_PRO_REASONING_PORTRAIT,
+      baseId === 'deepseek-v4-flash' || baseId === 'deepseek-v4-flash-vision-exp' ||
+      baseId === 'deepseek-v4-pro',
+    portrait: DEEPSEEK_V4_REASONING_PORTRAIT,
   },
   {
     matches: (_normalizedId, baseId) => matchesInterleavedReasoningBase(baseId),


### PR DESCRIPTION
The custom-provider fallback catalog contains superseded selections and lacks current Gemini, Kimi, GLM, StepFun, and Qwen models. Some retained entries also advertise outdated reasoning controls or pricing.

This change maintains 37 models across nine sources, replacing 13 selections with 13 additions. It retains GPT-5.5, Kimi K2.5, Gemini Flash models back through 3.5, and Gemini 3.1 Pro Preview.

| Source | Added | Removed from this fallback catalog |
| --- | --- | --- |
| OpenAI | — | `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.3-codex` |
| Gemini | `gemini-3.7-flash` | `gemini-2.5-pro` |
| Kimi | `kimi-k2.7-code` | `kimi-k2-thinking` |
| GLM | `glm-5.3`, `glm-5.3-flash` | `glm-5.1`, `glm-5`, `glm-5v-turbo`, `glm-4.7` |
| MiniMax | — | `MiniMax-M2.5`, `MiniMax-M2.5-highspeed` |
| StepFun | `step-3.7-flash`, `step-3.5-flash-2603`, `step-3.5-flash` | — |
| Qwen | `qwen3.8-max`, `qwen3.7-plus`, `qwen3.8-flash`, `qwen3-coder-plus`, `qwen3-coder-flash`, `qwen3-coder-next` | — |

- Reuse the existing seeded adapter for StepFun and Qwen. No additional credentials, network discovery adapters, dependencies, or CI changes are needed.
- Correct Gemini 3.7 thinking levels/defaults, Kimi always-on reasoning and fixed sampling controls, Kimi K3's output ceiling, and DeepSeek V4 Pro's effective effort levels. Refresh documented pricing and annotate regional, peak-hour, and temporary rates.
- Retain Kimi K2.5 as a legacy compatibility entry with its official August 31, 2026 sunset date. Catalog inclusion does not indicate current official endpoint availability.
- Document the complete selection and regenerate only `dist/custom-provider.json`. Other providers' templates and distribution files remain unchanged.

Validation:

- `pnpm build` and `pnpm exec tsc --noEmit` pass.
- All 45 existing/updated Node tests pass, including selection retention/removal and normalized capability controls.
- The built CLI generates the custom provider with all five discovery API keys unset and `MODELS_DEV_API_URL` pointing to the local `dist/all.json` snapshot. Output is written to a temporary directory.
- The documentation table, generated provider JSON, and temporary aggregate entry contain the same 37 unique IDs across nine sources. Kimi lifecycle metadata and model-specific reasoning controls survive the full generation pipeline.
- `git diff --check` passes. Live model inference was not called; ESLint is not installed in the repository toolchain.

Key official references: [Gemini 3.7](https://ai.google.dev/gemini-api/docs/latest-model), [Kimi models](https://platform.kimi.ai/docs/models), [Kimi API capabilities](https://platform.kimi.ai/docs/api/models-overview), [GLM-5.3](https://docs.z.ai/guides/llm/glm-5.3), [GLM-5.3 Flash](https://docs.z.ai/guides/vlm/glm-5.3-flash), [DeepSeek thinking controls](https://api-docs.deepseek.com/guides/thinking_mode/), [StepFun](https://platform.stepfun.ai/docs/en/guides/models/step-3.7-flash), [Qwen models](https://www.alibabacloud.com/help/en/model-studio/models). Model-card and pricing references are also retained in the seed catalog.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added StepFun and Qwen as supported custom provider sources.
  * Expanded the model catalog to 37 models across nine providers.
  * Added new model options, capabilities, pricing details, and lifecycle metadata.

* **Improvements**
  * Expanded DeepSeek V4 reasoning effort controls to low, high, and max across supported variants.
  * Updated provider model selections, compatibility, and availability information.

* **Documentation**
  * Updated custom provider documentation with the revised model catalog, pricing notes, configuration guidance, and provider logging details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->