### PR TITLE
feat(providers): update ollama template with new model families

### DIFF
--- a/dist/ollama.json
+++ b/dist/ollama.json
@@ -4,7 +4,7 @@
   "display_name": "Ollama Cloud",
   "metadata": {
     "source": "public-provider-conf",
-    "generated_at": "2026-07-05T06:32:55.481931Z"
+    "generated_at": "2026-09-09T09:11:21.632Z"
   },
   "models": [
     {
@@ -1206,6 +1206,29 @@
       }
     },
     {
+      "id": "command-r:35b",
+      "name": "command-r 35b",
+      "display_name": "command-r 35b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "command-r7b",
       "name": "command-r7b",
       "display_name": "command-r7b",
@@ -1287,29 +1310,6 @@
       "limit": {
         "context": 8192,
         "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "command-r:35b",
-      "name": "command-r 35b",
-      "display_name": "command-r 35b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
       },
       "modalities": {
         "input": [
@@ -1868,52 +1868,6 @@
       }
     },
     {
-      "id": "deepseek-v2.5",
-      "name": "deepseek-v2.5",
-      "display_name": "deepseek-v2.5",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 4096,
-        "output": 2048
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "deepseek-v2.5:236b",
-      "name": "deepseek-v2.5 236b",
-      "display_name": "deepseek-v2.5 236b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 128000,
-        "output": 64000
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
       "id": "deepseek-v2:16b",
       "name": "deepseek-v2 16b",
       "display_name": "deepseek-v2 16b",
@@ -1960,6 +1914,52 @@
       }
     },
     {
+      "id": "deepseek-v2.5",
+      "name": "deepseek-v2.5",
+      "display_name": "deepseek-v2.5",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 4096,
+        "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "deepseek-v2.5:236b",
+      "name": "deepseek-v2.5 236b",
+      "display_name": "deepseek-v2.5 236b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 128000,
+        "output": 64000
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "deepseek-v3",
       "name": "deepseek-v3",
       "display_name": "deepseek-v3",
@@ -1972,6 +1972,29 @@
       "limit": {
         "context": 4096,
         "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "deepseek-v3:671b",
+      "name": "deepseek-v3 671b",
+      "display_name": "deepseek-v3 671b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 65536,
+        "output": 32768
       },
       "modalities": {
         "input": [
@@ -2042,29 +2065,6 @@
       "limit": {
         "context": 4096,
         "output": 2048
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "deepseek-v3:671b",
-      "name": "deepseek-v3 671b",
-      "display_name": "deepseek-v3 671b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 65536,
-        "output": 32768
       },
       "modalities": {
         "input": [
@@ -2791,6 +2791,75 @@
       }
     },
     {
+      "id": "falcon:180b",
+      "name": "falcon 180b",
+      "display_name": "falcon 180b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 128000,
+        "output": 64000
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "falcon:40b",
+      "name": "falcon 40b",
+      "display_name": "falcon 40b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "falcon:7b",
+      "name": "falcon 7b",
+      "display_name": "falcon 7b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "falcon2",
       "name": "falcon2",
       "display_name": "falcon2",
@@ -2932,75 +3001,6 @@
       "id": "falcon3:7b",
       "name": "falcon3 7b",
       "display_name": "falcon3 7b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "falcon:180b",
-      "name": "falcon 180b",
-      "display_name": "falcon 180b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 128000,
-        "output": 64000
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "falcon:40b",
-      "name": "falcon 40b",
-      "display_name": "falcon 40b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "falcon:7b",
-      "name": "falcon 7b",
-      "display_name": "falcon 7b",
       "type": "chat",
       "reasoning": {
         "supported": false
@@ -3168,6 +3168,52 @@
       "limit": {
         "context": 4096,
         "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "gemma:2b",
+      "name": "gemma 2b",
+      "display_name": "gemma 2b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "gemma:7b",
+      "name": "gemma 7b",
+      "display_name": "gemma 7b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
       },
       "modalities": {
         "input": [
@@ -3538,52 +3584,6 @@
       "open_weights": true
     },
     {
-      "id": "gemma:2b",
-      "name": "gemma 2b",
-      "display_name": "gemma 2b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "gemma:7b",
-      "name": "gemma 7b",
-      "display_name": "gemma 7b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
       "id": "glm-4.7-flash",
       "name": "glm-4.7-flash",
       "display_name": "glm-4.7-flash",
@@ -3615,6 +3615,30 @@
       "id": "glm-4.7:cloud",
       "name": "glm-4.7 cloud",
       "display_name": "glm-4.7 cloud",
+      "type": "chat",
+      "reasoning": {
+        "supported": true,
+        "default": false
+      },
+      "tool_call": true,
+      "vision": false,
+      "limit": {
+        "context": 4096,
+        "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "glm-5:cloud",
+      "name": "glm-5 cloud",
+      "display_name": "glm-5 cloud",
       "type": "chat",
       "reasoning": {
         "supported": true,
@@ -3684,19 +3708,19 @@
       }
     },
     {
-      "id": "glm-5:cloud",
-      "name": "glm-5 cloud",
-      "display_name": "glm-5 cloud",
+      "id": "glm-5.3",
+      "name": "GLM-5.3",
+      "display_name": "GLM-5.3",
       "type": "chat",
       "reasoning": {
         "supported": true,
-        "default": false
+        "default": true
       },
       "tool_call": true,
       "vision": false,
       "limit": {
-        "context": 4096,
-        "output": 2048
+        "context": 1048576,
+        "output": 131072
       },
       "modalities": {
         "input": [
@@ -3705,7 +3729,98 @@
         "output": [
           "text"
         ]
-      }
+      },
+      "extra_capabilities": {
+        "reasoning": {
+          "supported": true,
+          "continuation": [
+            "thinking_blocks"
+          ],
+          "interleaved": true,
+          "summaries": true,
+          "visibility": "summary"
+        }
+      },
+      "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+      "family": "glm",
+      "attachment": false,
+      "reasoning_options": [
+        {
+          "type": "effort",
+          "values": [
+            "low",
+            "high",
+            "max"
+          ]
+        }
+      ],
+      "interleaved": {
+        "field": "reasoning_content"
+      },
+      "structured_output": true,
+      "temperature": true,
+      "release_date": "2026-08-14",
+      "last_updated": "2026-08-14",
+      "open_weights": true
+    },
+    {
+      "id": "glm-5.3-flash",
+      "name": "GLM-5.3-Flash",
+      "display_name": "GLM-5.3-Flash",
+      "type": "chat",
+      "reasoning": {
+        "supported": true,
+        "default": true
+      },
+      "tool_call": true,
+      "vision": true,
+      "limit": {
+        "context": 1000000,
+        "output": 131072
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "extra_capabilities": {
+        "reasoning": {
+          "supported": true,
+          "continuation": [
+            "thinking_blocks"
+          ],
+          "interleaved": true,
+          "summaries": true,
+          "visibility": "summary"
+        }
+      },
+      "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+      "family": "glm",
+      "attachment": true,
+      "reasoning_options": [
+        {
+          "type": "effort",
+          "values": [
+            "low",
+            "high",
+            "max"
+          ]
+        }
+      ],
+      "interleaved": {
+        "field": "reasoning_content"
+      },
+      "structured_output": true,
+      "temperature": true,
+      "release_date": "2026-08-26",
+      "last_updated": "2026-08-26",
+      "open_weights": true
     },
     {
       "id": "glm-ocr",
@@ -4710,6 +4825,75 @@
       }
     },
     {
+      "id": "granite4:1b",
+      "name": "granite4 1b",
+      "display_name": "granite4 1b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "granite4:350m",
+      "name": "granite4 350m",
+      "display_name": "granite4 350m",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "granite4:3b",
+      "name": "granite4 3b",
+      "display_name": "granite4 3b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "granite4.1-guardian:8b",
       "name": "granite4.1-guardian 8b",
       "display_name": "granite4.1-guardian 8b",
@@ -4802,64 +4986,19 @@
       }
     },
     {
-      "id": "granite4:1b",
-      "name": "granite4 1b",
-      "display_name": "granite4 1b",
+      "id": "granite4.2",
+      "name": "granite4.2",
+      "display_name": "granite4.2",
       "type": "chat",
       "reasoning": {
-        "supported": false
+        "supported": true,
+        "default": false
       },
       "tool_call": false,
       "vision": false,
       "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "granite4:350m",
-      "name": "granite4 350m",
-      "display_name": "granite4 350m",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "granite4:3b",
-      "name": "granite4 3b",
-      "display_name": "granite4 3b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
+        "context": 131072,
+        "output": 65536
       },
       "modalities": {
         "input": [
@@ -5153,6 +5292,86 @@
       }
     },
     {
+      "id": "kimi-k3",
+      "name": "kimi-k3",
+      "display_name": "kimi-k3",
+      "type": "chat",
+      "reasoning": {
+        "supported": true,
+        "default": true
+      },
+      "tool_call": true,
+      "vision": true,
+      "limit": {
+        "context": 1048576,
+        "output": 131072
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "extra_capabilities": {
+        "reasoning": {
+          "supported": true
+        }
+      },
+      "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
+      "family": "kimi-k3",
+      "attachment": true,
+      "reasoning_options": [
+        {
+          "type": "toggle"
+        },
+        {
+          "type": "effort",
+          "values": [
+            "low",
+            "high",
+            "max"
+          ]
+        }
+      ],
+      "structured_output": true,
+      "temperature": false,
+      "release_date": "2026-07-16",
+      "last_updated": "2026-07-27",
+      "open_weights": true
+    },
+    {
+      "id": "laguna-s-2.1",
+      "name": "laguna-s-2.1",
+      "display_name": "laguna-s-2.1",
+      "type": "chat",
+      "reasoning": {
+        "supported": true,
+        "default": false
+      },
+      "tool_call": true,
+      "vision": false,
+      "limit": {
+        "context": 262144,
+        "output": 131072
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "extra_capabilities": {
+        "reasoning": {
+          "supported": true
+        }
+      }
+    },
+    {
       "id": "laguna-xs-2.1:latest",
       "name": "laguna-xs-2.1 latest",
       "display_name": "laguna-xs-2.1 latest",
@@ -5223,6 +5442,29 @@
       }
     },
     {
+      "id": "lfm2:24b",
+      "name": "lfm2 24b",
+      "display_name": "lfm2 24b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "lfm2.5",
       "name": "lfm2.5",
       "display_name": "lfm2.5",
@@ -5272,29 +5514,6 @@
       "id": "lfm2.5:8b",
       "name": "lfm2.5 8b",
       "display_name": "lfm2.5 8b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "lfm2:24b",
-      "name": "lfm2 24b",
-      "display_name": "lfm2 24b",
       "type": "chat",
       "reasoning": {
         "supported": false
@@ -5867,6 +6086,52 @@
       }
     },
     {
+      "id": "llama3:70b",
+      "name": "llama3 70b",
+      "display_name": "llama3 70b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "llama3:8b",
+      "name": "llama3 8b",
+      "display_name": "llama3 8b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "llama3.1",
       "name": "llama3.1",
       "display_name": "llama3.1",
@@ -6135,52 +6400,6 @@
       "limit": {
         "context": 32768,
         "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "llama3:70b",
-      "name": "llama3 70b",
-      "display_name": "llama3 70b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "llama3:8b",
-      "name": "llama3 8b",
-      "display_name": "llama3 8b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
       },
       "modalities": {
         "input": [
@@ -6590,52 +6809,6 @@
       }
     },
     {
-      "id": "medgemma1.5",
-      "name": "medgemma1.5",
-      "display_name": "medgemma1.5",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 4096,
-        "output": 2048
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "medgemma1.5:4b",
-      "name": "medgemma1.5 4b",
-      "display_name": "medgemma1.5 4b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
       "id": "medgemma:27b",
       "name": "medgemma 27b",
       "display_name": "medgemma 27b",
@@ -6662,6 +6835,52 @@
       "id": "medgemma:4b",
       "name": "medgemma 4b",
       "display_name": "medgemma 4b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "medgemma1.5",
+      "name": "medgemma1.5",
+      "display_name": "medgemma1.5",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 4096,
+        "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "medgemma1.5:4b",
+      "name": "medgemma1.5 4b",
+      "display_name": "medgemma1.5 4b",
       "type": "chat",
       "reasoning": {
         "supported": false
@@ -6866,6 +7085,29 @@
       }
     },
     {
+      "id": "minicpm-v:8b",
+      "name": "minicpm-v 8b",
+      "display_name": "minicpm-v 8b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "minicpm-v4.5",
       "name": "minicpm-v4.5",
       "display_name": "minicpm-v4.5",
@@ -6947,29 +7189,6 @@
       "limit": {
         "context": 8192,
         "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "minicpm-v:8b",
-      "name": "minicpm-v 8b",
-      "display_name": "minicpm-v 8b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
       },
       "modalities": {
         "input": [
@@ -7424,6 +7643,52 @@
       }
     },
     {
+      "id": "mistral-small:22b",
+      "name": "mistral-small 22b",
+      "display_name": "mistral-small 22b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "mistral-small:24b",
+      "name": "mistral-small 24b",
+      "display_name": "mistral-small 24b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "mistral-small3.1",
       "name": "mistral-small3.1",
       "display_name": "mistral-small3.1",
@@ -7496,52 +7761,6 @@
       "id": "mistral-small3.2:24b",
       "name": "mistral-small3.2 24b",
       "display_name": "mistral-small3.2 24b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "mistral-small:22b",
-      "name": "mistral-small 22b",
-      "display_name": "mistral-small 22b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "mistral-small:24b",
-      "name": "mistral-small 24b",
-      "display_name": "mistral-small 24b",
       "type": "chat",
       "reasoning": {
         "supported": false
@@ -7666,6 +7885,31 @@
       "limit": {
         "context": 4096,
         "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "muse-glimmer",
+      "name": "muse-glimmer",
+      "display_name": "muse-glimmer",
+      "type": "chat",
+      "reasoning": {
+        "supported": true,
+        "default": false
+      },
+      "tool_call": true,
+      "vision": true,
+      "limit": {
+        "context": 131072,
+        "output": 65536
       },
       "modalities": {
         "input": [
@@ -7912,6 +8156,35 @@
       }
     },
     {
+      "id": "nemotron-3.5-lightning",
+      "name": "nemotron-3.5-lightning",
+      "display_name": "nemotron-3.5-lightning",
+      "type": "chat",
+      "reasoning": {
+        "supported": true,
+        "default": false
+      },
+      "tool_call": true,
+      "vision": false,
+      "limit": {
+        "context": 1048576,
+        "output": 524288
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "extra_capabilities": {
+        "reasoning": {
+          "supported": true
+        }
+      }
+    },
+    {
       "id": "nemotron-cascade-2",
       "name": "nemotron-cascade-2",
       "display_name": "nemotron-cascade-2",
@@ -8004,29 +8277,6 @@
       }
     },
     {
-      "id": "nemotron3:33b",
-      "name": "nemotron3 33b",
-      "display_name": "nemotron3 33b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
       "id": "nemotron:70b",
       "name": "nemotron 70b",
       "display_name": "nemotron 70b",
@@ -8039,6 +8289,29 @@
       "limit": {
         "context": 32768,
         "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "nemotron3:33b",
+      "name": "nemotron3 33b",
+      "display_name": "nemotron3 33b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
       },
       "modalities": {
         "input": [
@@ -8303,6 +8576,52 @@
       }
     },
     {
+      "id": "nous-hermes:13b",
+      "name": "nous-hermes 13b",
+      "display_name": "nous-hermes 13b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "nous-hermes:7b",
+      "name": "nous-hermes 7b",
+      "display_name": "nous-hermes 7b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "nous-hermes2",
       "name": "nous-hermes2",
       "display_name": "nous-hermes2",
@@ -8372,52 +8691,6 @@
       }
     },
     {
-      "id": "nous-hermes:13b",
-      "name": "nous-hermes 13b",
-      "display_name": "nous-hermes 13b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "nous-hermes:7b",
-      "name": "nous-hermes 7b",
-      "display_name": "nous-hermes 7b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
       "id": "nuextract",
       "name": "nuextract",
       "display_name": "nuextract",
@@ -8464,52 +8737,6 @@
       }
     },
     {
-      "id": "olmo-3.1",
-      "name": "olmo-3.1",
-      "display_name": "olmo-3.1",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 4096,
-        "output": 2048
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "olmo-3.1:32b",
-      "name": "olmo-3.1 32b",
-      "display_name": "olmo-3.1 32b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
       "id": "olmo-3:32b",
       "name": "olmo-3 32b",
       "display_name": "olmo-3 32b",
@@ -8545,6 +8772,52 @@
       "limit": {
         "context": 8192,
         "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "olmo-3.1",
+      "name": "olmo-3.1",
+      "display_name": "olmo-3.1",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 4096,
+        "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "olmo-3.1:32b",
+      "name": "olmo-3.1 32b",
+      "display_name": "olmo-3.1 32b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
       },
       "modalities": {
         "input": [
@@ -9039,6 +9312,30 @@
       }
     },
     {
+      "id": "ornith-1.5",
+      "name": "ornith-1.5",
+      "display_name": "ornith-1.5",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": true,
+      "limit": {
+        "context": 262144,
+        "output": 131072
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "ornith:35b",
       "name": "ornith 35b",
       "display_name": "ornith 35b",
@@ -9200,29 +9497,6 @@
       }
     },
     {
-      "id": "phi3.5",
-      "name": "phi3.5",
-      "display_name": "phi3.5",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 4096,
-        "output": 2048
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
       "id": "phi3:14b",
       "name": "phi3 14b",
       "display_name": "phi3 14b",
@@ -9235,6 +9509,29 @@
       "limit": {
         "context": 16384,
         "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "phi3.5",
+      "name": "phi3.5",
+      "display_name": "phi3.5",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 4096,
+        "output": 2048
       },
       "modalities": {
         "input": [
@@ -9456,6 +9753,190 @@
       }
     },
     {
+      "id": "qwen:0.5b",
+      "name": "qwen 0.5b",
+      "display_name": "qwen 0.5b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen:1.8b",
+      "name": "qwen 1.8b",
+      "display_name": "qwen 1.8b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen:110b",
+      "name": "qwen 110b",
+      "display_name": "qwen 110b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen:14b",
+      "name": "qwen 14b",
+      "display_name": "qwen 14b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen:32b",
+      "name": "qwen 32b",
+      "display_name": "qwen 32b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen:4b",
+      "name": "qwen 4b",
+      "display_name": "qwen 4b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen:72b",
+      "name": "qwen 72b",
+      "display_name": "qwen 72b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen:7b",
+      "name": "qwen 7b",
+      "display_name": "qwen 7b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "qwen2",
       "name": "qwen2",
       "display_name": "qwen2",
@@ -9528,6 +10009,52 @@
       "id": "qwen2-math:7b",
       "name": "qwen2-math 7b",
       "display_name": "qwen2-math 7b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen2:72b",
+      "name": "qwen2 72b",
+      "display_name": "qwen2 72b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen2:7b",
+      "name": "qwen2 7b",
+      "display_name": "qwen2 7b",
       "type": "chat",
       "reasoning": {
         "supported": false
@@ -9896,52 +10423,6 @@
       "id": "qwen2.5vl:7b",
       "name": "qwen2.5vl 7b",
       "display_name": "qwen2.5vl 7b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen2:72b",
-      "name": "qwen2 72b",
-      "display_name": "qwen2 72b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen2:7b",
-      "name": "qwen2 7b",
-      "display_name": "qwen2 7b",
       "type": "chat",
       "reasoning": {
         "supported": false
@@ -10353,6 +10834,144 @@
       }
     },
     {
+      "id": "qwen3:14b",
+      "name": "qwen3 14b",
+      "display_name": "qwen3 14b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen3:235b",
+      "name": "qwen3 235b",
+      "display_name": "qwen3 235b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 128000,
+        "output": 64000
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen3:30b",
+      "name": "qwen3 30b",
+      "display_name": "qwen3 30b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen3:32b",
+      "name": "qwen3 32b",
+      "display_name": "qwen3 32b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen3:4b",
+      "name": "qwen3 4b",
+      "display_name": "qwen3 4b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen3:8b",
+      "name": "qwen3 8b",
+      "display_name": "qwen3 8b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "qwen3.5",
       "name": "qwen3.5",
       "display_name": "qwen3.5",
@@ -10583,22 +11202,24 @@
       }
     },
     {
-      "id": "qwen3:14b",
-      "name": "qwen3 14b",
-      "display_name": "qwen3 14b",
+      "id": "qwen3.8",
+      "name": "qwen3.8",
+      "display_name": "qwen3.8",
       "type": "chat",
       "reasoning": {
-        "supported": false
+        "supported": true,
+        "default": true
       },
-      "tool_call": false,
-      "vision": false,
+      "tool_call": true,
+      "vision": true,
       "limit": {
-        "context": 16384,
-        "output": 8192
+        "context": 262144,
+        "output": 131072
       },
       "modalities": {
         "input": [
-          "text"
+          "text",
+          "image"
         ],
         "output": [
           "text"
@@ -10606,298 +11227,24 @@
       }
     },
     {
-      "id": "qwen3:235b",
-      "name": "qwen3 235b",
-      "display_name": "qwen3 235b",
+      "id": "qwen3.8-flash-next",
+      "name": "qwen3.8-flash-next",
+      "display_name": "qwen3.8-flash-next",
       "type": "chat",
       "reasoning": {
-        "supported": false
+        "supported": true,
+        "default": true
       },
-      "tool_call": false,
-      "vision": false,
+      "tool_call": true,
+      "vision": true,
       "limit": {
-        "context": 128000,
-        "output": 64000
+        "context": 262144,
+        "output": 131072
       },
       "modalities": {
         "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen3:30b",
-      "name": "qwen3 30b",
-      "display_name": "qwen3 30b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen3:32b",
-      "name": "qwen3 32b",
-      "display_name": "qwen3 32b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen3:4b",
-      "name": "qwen3 4b",
-      "display_name": "qwen3 4b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen3:8b",
-      "name": "qwen3 8b",
-      "display_name": "qwen3 8b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen:0.5b",
-      "name": "qwen 0.5b",
-      "display_name": "qwen 0.5b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen:1.8b",
-      "name": "qwen 1.8b",
-      "display_name": "qwen 1.8b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen:110b",
-      "name": "qwen 110b",
-      "display_name": "qwen 110b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen:14b",
-      "name": "qwen 14b",
-      "display_name": "qwen 14b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen:32b",
-      "name": "qwen 32b",
-      "display_name": "qwen 32b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen:4b",
-      "name": "qwen 4b",
-      "display_name": "qwen 4b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen:72b",
-      "name": "qwen 72b",
-      "display_name": "qwen 72b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen:7b",
-      "name": "qwen 7b",
-      "display_name": "qwen 7b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
+          "text",
+          "image"
         ],
         "output": [
           "text"
@@ -11437,6 +11784,52 @@
       }
     },
     {
+      "id": "smollm:135m",
+      "name": "smollm 135m",
+      "display_name": "smollm 135m",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "smollm:360m",
+      "name": "smollm 360m",
+      "display_name": "smollm 360m",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "smollm2",
       "name": "smollm2",
       "display_name": "smollm2",
@@ -11506,52 +11899,6 @@
       }
     },
     {
-      "id": "smollm:135m",
-      "name": "smollm 135m",
-      "display_name": "smollm 135m",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "smollm:360m",
-      "name": "smollm 360m",
-      "display_name": "smollm 360m",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
       "id": "snowflake-arctic-embed",
       "name": "snowflake-arctic-embed",
       "display_name": "snowflake-arctic-embed",
@@ -11564,52 +11911,6 @@
       "limit": {
         "context": 4096,
         "output": 2048
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "snowflake-arctic-embed2",
-      "name": "snowflake-arctic-embed2",
-      "display_name": "snowflake-arctic-embed2",
-      "type": "embedding",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 4096,
-        "output": 2048
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "snowflake-arctic-embed2:568m",
-      "name": "snowflake-arctic-embed2 568m",
-      "display_name": "snowflake-arctic-embed2 568m",
-      "type": "embedding",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
       },
       "modalities": {
         "input": [
@@ -11716,6 +12017,52 @@
       "id": "snowflake-arctic-embed:33m",
       "name": "snowflake-arctic-embed 33m",
       "display_name": "snowflake-arctic-embed 33m",
+      "type": "embedding",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "snowflake-arctic-embed2",
+      "name": "snowflake-arctic-embed2",
+      "display_name": "snowflake-arctic-embed2",
+      "type": "embedding",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 4096,
+        "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "snowflake-arctic-embed2:568m",
+      "name": "snowflake-arctic-embed2 568m",
+      "display_name": "snowflake-arctic-embed2 568m",
       "type": "embedding",
       "reasoning": {
         "supported": false
@@ -12127,98 +12474,6 @@
       }
     },
     {
-      "id": "starcoder2",
-      "name": "starcoder2",
-      "display_name": "starcoder2",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": true,
-      "vision": false,
-      "limit": {
-        "context": 4096,
-        "output": 2048
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "starcoder2:15b",
-      "name": "starcoder2 15b",
-      "display_name": "starcoder2 15b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": true,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "starcoder2:3b",
-      "name": "starcoder2 3b",
-      "display_name": "starcoder2 3b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": true,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "starcoder2:7b",
-      "name": "starcoder2 7b",
-      "display_name": "starcoder2 7b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": true,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
       "id": "starcoder:15b",
       "name": "starcoder 15b",
       "display_name": "starcoder 15b",
@@ -12291,6 +12546,98 @@
       "id": "starcoder:7b",
       "name": "starcoder 7b",
       "display_name": "starcoder 7b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": true,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "starcoder2",
+      "name": "starcoder2",
+      "display_name": "starcoder2",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": true,
+      "vision": false,
+      "limit": {
+        "context": 4096,
+        "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "starcoder2:15b",
+      "name": "starcoder2 15b",
+      "display_name": "starcoder2 15b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": true,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "starcoder2:3b",
+      "name": "starcoder2 3b",
+      "display_name": "starcoder2 3b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": true,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "starcoder2:7b",
+      "name": "starcoder2 7b",
+      "display_name": "starcoder2 7b",
       "type": "chat",
       "reasoning": {
         "supported": false
@@ -12978,6 +13325,29 @@
       }
     },
     {
+      "id": "wizardlm:7b-q2_K",
+      "name": "wizardlm 7b-q2_K",
+      "display_name": "wizardlm 7b-q2_K",
+      "type": "chat",
+      "reasoning": {
+        "supported": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 2048,
+        "output": 1024
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "wizardlm2",
       "name": "wizardlm2",
       "display_name": "wizardlm2",
@@ -13013,29 +13383,6 @@
       "limit": {
         "context": 8192,
         "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "wizardlm:7b-q2_K",
-      "name": "wizardlm 7b-q2_K",
-      "display_name": "wizardlm 7b-q2_K",
-      "type": "chat",
-      "reasoning": {
-        "supported": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 2048,
-        "output": 1024
       },
       "modalities": {
         "input": [
@@ -13928,114 +14275,6 @@
       "type": "chat"
     },
     {
-      "id": "kimi-k3",
-      "name": "kimi-k3",
-      "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
-      "family": "kimi-k3",
-      "attachment": true,
-      "reasoning": {
-        "supported": true,
-        "default": true
-      },
-      "reasoning_options": [
-        {
-          "type": "toggle"
-        },
-        {
-          "type": "effort",
-          "values": [
-            "low",
-            "high",
-            "max"
-          ]
-        }
-      ],
-      "tool_call": true,
-      "structured_output": true,
-      "temperature": false,
-      "release_date": "2026-07-16",
-      "last_updated": "2026-07-27",
-      "modalities": {
-        "input": [
-          "text",
-          "image"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "open_weights": true,
-      "limit": {
-        "context": 1048576,
-        "output": 131072
-      },
-      "display_name": "kimi-k3",
-      "extra_capabilities": {
-        "reasoning": {
-          "supported": true
-        }
-      },
-      "type": "chat"
-    },
-    {
-      "id": "glm-5.3-flash",
-      "name": "GLM-5.3-Flash",
-      "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
-      "family": "glm",
-      "attachment": true,
-      "reasoning": {
-        "supported": true,
-        "default": true
-      },
-      "reasoning_options": [
-        {
-          "type": "effort",
-          "values": [
-            "low",
-            "high",
-            "max"
-          ]
-        }
-      ],
-      "tool_call": true,
-      "interleaved": {
-        "field": "reasoning_content"
-      },
-      "structured_output": true,
-      "temperature": true,
-      "release_date": "2026-08-26",
-      "last_updated": "2026-08-26",
-      "modalities": {
-        "input": [
-          "text",
-          "image",
-          "video",
-          "pdf"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "open_weights": true,
-      "limit": {
-        "context": 1000000,
-        "output": 131072
-      },
-      "display_name": "GLM-5.3-Flash",
-      "extra_capabilities": {
-        "reasoning": {
-          "supported": true,
-          "continuation": [
-            "thinking_blocks"
-          ],
-          "interleaved": true,
-          "summaries": true,
-          "visibility": "summary"
-        }
-      },
-      "type": "chat"
-    },
-    {
       "id": "kimi-k2.5",
       "name": "kimi-k2.5",
       "description": "Kimi multimodal agent model for visual understanding, coding, and planning",
@@ -14188,61 +14427,6 @@
           "notes": [
             "The DeepSeek API maps medium and xhigh to high for V4 models; effort_options lists distinct model-effective levels."
           ]
-        }
-      },
-      "type": "chat"
-    },
-    {
-      "id": "glm-5.3",
-      "name": "GLM-5.3",
-      "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
-      "family": "glm",
-      "attachment": false,
-      "reasoning": {
-        "supported": true,
-        "default": true
-      },
-      "reasoning_options": [
-        {
-          "type": "effort",
-          "values": [
-            "low",
-            "high",
-            "max"
-          ]
-        }
-      ],
-      "tool_call": true,
-      "interleaved": {
-        "field": "reasoning_content"
-      },
-      "structured_output": true,
-      "temperature": true,
-      "release_date": "2026-08-14",
-      "last_updated": "2026-08-14",
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "open_weights": true,
-      "limit": {
-        "context": 1048576,
-        "output": 131072
-      },
-      "display_name": "GLM-5.3",
-      "extra_capabilities": {
-        "reasoning": {
-          "supported": true,
-          "continuation": [
-            "thinking_blocks"
-          ],
-          "interleaved": true,
-          "summaries": true,
-          "visibility": "summary"
         }
       },
       "type": "chat"

--- a/manual-templates/ollama.json
+++ b/manual-templates/ollama.json
@@ -4,7 +4,7 @@
   "display_name": "Ollama",
   "metadata": {
     "source": "public-provider-conf",
-    "generated_at": "2026-07-05T06:32:55.481931Z"
+    "generated_at": "2026-09-09T09:11:21.632Z"
   },
   "models": [
     {
@@ -1258,6 +1258,30 @@
       }
     },
     {
+      "id": "command-r:35b",
+      "name": "command-r 35b",
+      "display_name": "command-r 35b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "command-r7b",
       "name": "command-r7b",
       "display_name": "command-r7b",
@@ -1343,30 +1367,6 @@
       "limit": {
         "context": 8192,
         "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "command-r:35b",
-      "name": "command-r 35b",
-      "display_name": "command-r 35b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
       },
       "modalities": {
         "input": [
@@ -1930,54 +1930,6 @@
       }
     },
     {
-      "id": "deepseek-v2.5",
-      "name": "deepseek-v2.5",
-      "display_name": "deepseek-v2.5",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 4096,
-        "output": 2048
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "deepseek-v2.5:236b",
-      "name": "deepseek-v2.5 236b",
-      "display_name": "deepseek-v2.5 236b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 128000,
-        "output": 64000
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
       "id": "deepseek-v2:16b",
       "name": "deepseek-v2 16b",
       "display_name": "deepseek-v2 16b",
@@ -2026,6 +1978,54 @@
       }
     },
     {
+      "id": "deepseek-v2.5",
+      "name": "deepseek-v2.5",
+      "display_name": "deepseek-v2.5",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 4096,
+        "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "deepseek-v2.5:236b",
+      "name": "deepseek-v2.5 236b",
+      "display_name": "deepseek-v2.5 236b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 128000,
+        "output": 64000
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "deepseek-v3",
       "name": "deepseek-v3",
       "display_name": "deepseek-v3",
@@ -2039,6 +2039,30 @@
       "limit": {
         "context": 4096,
         "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "deepseek-v3:671b",
+      "name": "deepseek-v3 671b",
+      "display_name": "deepseek-v3 671b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 65536,
+        "output": 32768
       },
       "modalities": {
         "input": [
@@ -2111,30 +2135,6 @@
       "limit": {
         "context": 4096,
         "output": 2048
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "deepseek-v3:671b",
-      "name": "deepseek-v3 671b",
-      "display_name": "deepseek-v3 671b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 65536,
-        "output": 32768
       },
       "modalities": {
         "input": [
@@ -2890,6 +2890,78 @@
       }
     },
     {
+      "id": "falcon:180b",
+      "name": "falcon 180b",
+      "display_name": "falcon 180b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 128000,
+        "output": 64000
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "falcon:40b",
+      "name": "falcon 40b",
+      "display_name": "falcon 40b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "falcon:7b",
+      "name": "falcon 7b",
+      "display_name": "falcon 7b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "falcon2",
       "name": "falcon2",
       "display_name": "falcon2",
@@ -3058,78 +3130,6 @@
       }
     },
     {
-      "id": "falcon:180b",
-      "name": "falcon 180b",
-      "display_name": "falcon 180b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 128000,
-        "output": 64000
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "falcon:40b",
-      "name": "falcon 40b",
-      "display_name": "falcon 40b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "falcon:7b",
-      "name": "falcon 7b",
-      "display_name": "falcon 7b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
       "id": "firefunction-v2",
       "name": "firefunction-v2",
       "display_name": "firefunction-v2",
@@ -3263,6 +3263,54 @@
       "limit": {
         "context": 4096,
         "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "gemma:2b",
+      "name": "gemma 2b",
+      "display_name": "gemma 2b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "gemma:7b",
+      "name": "gemma 7b",
+      "display_name": "gemma 7b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
       },
       "modalities": {
         "input": [
@@ -3634,54 +3682,6 @@
       }
     },
     {
-      "id": "gemma:2b",
-      "name": "gemma 2b",
-      "display_name": "gemma 2b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "gemma:7b",
-      "name": "gemma 7b",
-      "display_name": "gemma 7b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
       "id": "glm-4.7-flash",
       "name": "glm-4.7-flash",
       "display_name": "glm-4.7-flash",
@@ -3709,6 +3709,30 @@
       "id": "glm-4.7:cloud",
       "name": "glm-4.7 cloud",
       "display_name": "glm-4.7 cloud",
+      "type": "chat",
+      "reasoning": {
+        "supported": true,
+        "default": false
+      },
+      "tool_call": true,
+      "vision": false,
+      "limit": {
+        "context": 4096,
+        "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "glm-5:cloud",
+      "name": "glm-5 cloud",
+      "display_name": "glm-5 cloud",
       "type": "chat",
       "reasoning": {
         "supported": true,
@@ -3778,9 +3802,9 @@
       }
     },
     {
-      "id": "glm-5:cloud",
-      "name": "glm-5 cloud",
-      "display_name": "glm-5 cloud",
+      "id": "glm-5.3",
+      "name": "glm-5.3",
+      "display_name": "glm-5.3",
       "type": "chat",
       "reasoning": {
         "supported": true,
@@ -3795,6 +3819,31 @@
       "modalities": {
         "input": [
           "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "glm-5.3-flash",
+      "name": "glm-5.3-flash",
+      "display_name": "glm-5.3-flash",
+      "type": "chat",
+      "reasoning": {
+        "supported": true,
+        "default": false
+      },
+      "tool_call": true,
+      "vision": true,
+      "limit": {
+        "context": 4096,
+        "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
         ],
         "output": [
           "text"
@@ -4812,6 +4861,78 @@
       }
     },
     {
+      "id": "granite4:1b",
+      "name": "granite4 1b",
+      "display_name": "granite4 1b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "granite4:350m",
+      "name": "granite4 350m",
+      "display_name": "granite4 350m",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "granite4:3b",
+      "name": "granite4 3b",
+      "display_name": "granite4 3b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "granite4.1-guardian:8b",
       "name": "granite4.1-guardian 8b",
       "display_name": "granite4.1-guardian 8b",
@@ -4908,67 +5029,19 @@
       }
     },
     {
-      "id": "granite4:1b",
-      "name": "granite4 1b",
-      "display_name": "granite4 1b",
+      "id": "granite4.2",
+      "name": "granite4.2",
+      "display_name": "granite4.2",
       "type": "chat",
       "reasoning": {
-        "supported": false,
+        "supported": true,
         "default": false
       },
       "tool_call": false,
       "vision": false,
       "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "granite4:350m",
-      "name": "granite4 350m",
-      "display_name": "granite4 350m",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "granite4:3b",
-      "name": "granite4 3b",
-      "display_name": "granite4 3b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
+        "context": 131072,
+        "output": 65536
       },
       "modalities": {
         "input": [
@@ -5271,6 +5344,55 @@
       }
     },
     {
+      "id": "kimi-k3",
+      "name": "kimi-k3",
+      "display_name": "kimi-k3",
+      "type": "chat",
+      "reasoning": {
+        "supported": true,
+        "default": false
+      },
+      "tool_call": true,
+      "vision": true,
+      "limit": {
+        "context": 4096,
+        "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "laguna-s-2.1",
+      "name": "laguna-s-2.1",
+      "display_name": "laguna-s-2.1",
+      "type": "chat",
+      "reasoning": {
+        "supported": true,
+        "default": false
+      },
+      "tool_call": true,
+      "vision": false,
+      "limit": {
+        "context": 262144,
+        "output": 131072
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "laguna-xs-2.1:latest",
       "name": "laguna-xs-2.1 latest",
       "display_name": "laguna-xs-2.1 latest",
@@ -5343,6 +5465,30 @@
       }
     },
     {
+      "id": "lfm2:24b",
+      "name": "lfm2 24b",
+      "display_name": "lfm2 24b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "lfm2.5",
       "name": "lfm2.5",
       "display_name": "lfm2.5",
@@ -5394,30 +5540,6 @@
       "id": "lfm2.5:8b",
       "name": "lfm2.5 8b",
       "display_name": "lfm2.5 8b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "lfm2:24b",
-      "name": "lfm2 24b",
-      "display_name": "lfm2 24b",
       "type": "chat",
       "reasoning": {
         "supported": false,
@@ -6015,6 +6137,54 @@
       }
     },
     {
+      "id": "llama3:70b",
+      "name": "llama3 70b",
+      "display_name": "llama3 70b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "llama3:8b",
+      "name": "llama3 8b",
+      "display_name": "llama3 8b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "llama3.1",
       "name": "llama3.1",
       "display_name": "llama3.1",
@@ -6295,54 +6465,6 @@
       "limit": {
         "context": 32768,
         "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "llama3:70b",
-      "name": "llama3 70b",
-      "display_name": "llama3 70b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "llama3:8b",
-      "name": "llama3 8b",
-      "display_name": "llama3 8b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
       },
       "modalities": {
         "input": [
@@ -6769,54 +6891,6 @@
       }
     },
     {
-      "id": "medgemma1.5",
-      "name": "medgemma1.5",
-      "display_name": "medgemma1.5",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 4096,
-        "output": 2048
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "medgemma1.5:4b",
-      "name": "medgemma1.5 4b",
-      "display_name": "medgemma1.5 4b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
       "id": "medgemma:27b",
       "name": "medgemma 27b",
       "display_name": "medgemma 27b",
@@ -6844,6 +6918,54 @@
       "id": "medgemma:4b",
       "name": "medgemma 4b",
       "display_name": "medgemma 4b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "medgemma1.5",
+      "name": "medgemma1.5",
+      "display_name": "medgemma1.5",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 4096,
+        "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "medgemma1.5:4b",
+      "name": "medgemma1.5 4b",
+      "display_name": "medgemma1.5 4b",
       "type": "chat",
       "reasoning": {
         "supported": false,
@@ -7057,6 +7179,30 @@
       }
     },
     {
+      "id": "minicpm-v:8b",
+      "name": "minicpm-v 8b",
+      "display_name": "minicpm-v 8b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "minicpm-v4.5",
       "name": "minicpm-v4.5",
       "display_name": "minicpm-v4.5",
@@ -7142,30 +7288,6 @@
       "limit": {
         "context": 8192,
         "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "minicpm-v:8b",
-      "name": "minicpm-v 8b",
-      "display_name": "minicpm-v 8b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
       },
       "modalities": {
         "input": [
@@ -7635,6 +7757,54 @@
       }
     },
     {
+      "id": "mistral-small:22b",
+      "name": "mistral-small 22b",
+      "display_name": "mistral-small 22b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "mistral-small:24b",
+      "name": "mistral-small 24b",
+      "display_name": "mistral-small 24b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "mistral-small3.1",
       "name": "mistral-small3.1",
       "display_name": "mistral-small3.1",
@@ -7710,54 +7880,6 @@
       "id": "mistral-small3.2:24b",
       "name": "mistral-small3.2 24b",
       "display_name": "mistral-small3.2 24b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "mistral-small:22b",
-      "name": "mistral-small 22b",
-      "display_name": "mistral-small 22b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "mistral-small:24b",
-      "name": "mistral-small 24b",
-      "display_name": "mistral-small 24b",
       "type": "chat",
       "reasoning": {
         "supported": false,
@@ -7888,6 +8010,31 @@
       "limit": {
         "context": 4096,
         "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "muse-glimmer",
+      "name": "muse-glimmer",
+      "display_name": "muse-glimmer",
+      "type": "chat",
+      "reasoning": {
+        "supported": true,
+        "default": false
+      },
+      "tool_call": true,
+      "vision": true,
+      "limit": {
+        "context": 131072,
+        "output": 65536
       },
       "modalities": {
         "input": [
@@ -8116,6 +8263,30 @@
       }
     },
     {
+      "id": "nemotron-3.5-lightning",
+      "name": "nemotron-3.5-lightning",
+      "display_name": "nemotron-3.5-lightning",
+      "type": "chat",
+      "reasoning": {
+        "supported": true,
+        "default": false
+      },
+      "tool_call": true,
+      "vision": false,
+      "limit": {
+        "context": 1048576,
+        "output": 524288
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "nemotron-cascade-2",
       "name": "nemotron-cascade-2",
       "display_name": "nemotron-cascade-2",
@@ -8212,30 +8383,6 @@
       }
     },
     {
-      "id": "nemotron3:33b",
-      "name": "nemotron3 33b",
-      "display_name": "nemotron3 33b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
       "id": "nemotron:70b",
       "name": "nemotron 70b",
       "display_name": "nemotron 70b",
@@ -8249,6 +8396,30 @@
       "limit": {
         "context": 32768,
         "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "nemotron3:33b",
+      "name": "nemotron3 33b",
+      "display_name": "nemotron3 33b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
       },
       "modalities": {
         "input": [
@@ -8524,6 +8695,54 @@
       }
     },
     {
+      "id": "nous-hermes:13b",
+      "name": "nous-hermes 13b",
+      "display_name": "nous-hermes 13b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "nous-hermes:7b",
+      "name": "nous-hermes 7b",
+      "display_name": "nous-hermes 7b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "nous-hermes2",
       "name": "nous-hermes2",
       "display_name": "nous-hermes2",
@@ -8596,54 +8815,6 @@
       }
     },
     {
-      "id": "nous-hermes:13b",
-      "name": "nous-hermes 13b",
-      "display_name": "nous-hermes 13b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "nous-hermes:7b",
-      "name": "nous-hermes 7b",
-      "display_name": "nous-hermes 7b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
       "id": "nuextract",
       "name": "nuextract",
       "display_name": "nuextract",
@@ -8692,54 +8863,6 @@
       }
     },
     {
-      "id": "olmo-3.1",
-      "name": "olmo-3.1",
-      "display_name": "olmo-3.1",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 4096,
-        "output": 2048
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "olmo-3.1:32b",
-      "name": "olmo-3.1 32b",
-      "display_name": "olmo-3.1 32b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
       "id": "olmo-3:32b",
       "name": "olmo-3 32b",
       "display_name": "olmo-3 32b",
@@ -8777,6 +8900,54 @@
       "limit": {
         "context": 8192,
         "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "olmo-3.1",
+      "name": "olmo-3.1",
+      "display_name": "olmo-3.1",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 4096,
+        "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "olmo-3.1:32b",
+      "name": "olmo-3.1 32b",
+      "display_name": "olmo-3.1 32b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
       },
       "modalities": {
         "input": [
@@ -9292,6 +9463,31 @@
       }
     },
     {
+      "id": "ornith-1.5",
+      "name": "ornith-1.5",
+      "display_name": "ornith-1.5",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": true,
+      "limit": {
+        "context": 262144,
+        "output": 131072
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "ornith:35b",
       "name": "ornith 35b",
       "display_name": "ornith 35b",
@@ -9460,30 +9656,6 @@
       }
     },
     {
-      "id": "phi3.5",
-      "name": "phi3.5",
-      "display_name": "phi3.5",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 4096,
-        "output": 2048
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
       "id": "phi3:14b",
       "name": "phi3 14b",
       "display_name": "phi3 14b",
@@ -9497,6 +9669,30 @@
       "limit": {
         "context": 16384,
         "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "phi3.5",
+      "name": "phi3.5",
+      "display_name": "phi3.5",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 4096,
+        "output": 2048
       },
       "modalities": {
         "input": [
@@ -9724,6 +9920,198 @@
       }
     },
     {
+      "id": "qwen:0.5b",
+      "name": "qwen 0.5b",
+      "display_name": "qwen 0.5b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen:1.8b",
+      "name": "qwen 1.8b",
+      "display_name": "qwen 1.8b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen:110b",
+      "name": "qwen 110b",
+      "display_name": "qwen 110b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen:14b",
+      "name": "qwen 14b",
+      "display_name": "qwen 14b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen:32b",
+      "name": "qwen 32b",
+      "display_name": "qwen 32b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen:4b",
+      "name": "qwen 4b",
+      "display_name": "qwen 4b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen:72b",
+      "name": "qwen 72b",
+      "display_name": "qwen 72b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen:7b",
+      "name": "qwen 7b",
+      "display_name": "qwen 7b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "qwen2",
       "name": "qwen2",
       "display_name": "qwen2",
@@ -9799,6 +10187,54 @@
       "id": "qwen2-math:7b",
       "name": "qwen2-math 7b",
       "display_name": "qwen2-math 7b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen2:72b",
+      "name": "qwen2 72b",
+      "display_name": "qwen2 72b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 32768,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen2:7b",
+      "name": "qwen2 7b",
+      "display_name": "qwen2 7b",
       "type": "chat",
       "reasoning": {
         "supported": false,
@@ -10183,54 +10619,6 @@
       "id": "qwen2.5vl:7b",
       "name": "qwen2.5vl 7b",
       "display_name": "qwen2.5vl 7b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen2:72b",
-      "name": "qwen2 72b",
-      "display_name": "qwen2 72b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen2:7b",
-      "name": "qwen2 7b",
-      "display_name": "qwen2 7b",
       "type": "chat",
       "reasoning": {
         "supported": false,
@@ -10660,6 +11048,150 @@
       }
     },
     {
+      "id": "qwen3:14b",
+      "name": "qwen3 14b",
+      "display_name": "qwen3 14b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen3:235b",
+      "name": "qwen3 235b",
+      "display_name": "qwen3 235b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 128000,
+        "output": 64000
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen3:30b",
+      "name": "qwen3 30b",
+      "display_name": "qwen3 30b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen3:32b",
+      "name": "qwen3 32b",
+      "display_name": "qwen3 32b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen3:4b",
+      "name": "qwen3 4b",
+      "display_name": "qwen3 4b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "qwen3:8b",
+      "name": "qwen3 8b",
+      "display_name": "qwen3 8b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "qwen3.5",
       "name": "qwen3.5",
       "display_name": "qwen3.5",
@@ -10900,23 +11432,24 @@
       }
     },
     {
-      "id": "qwen3:14b",
-      "name": "qwen3 14b",
-      "display_name": "qwen3 14b",
+      "id": "qwen3.8",
+      "name": "qwen3.8",
+      "display_name": "qwen3.8",
       "type": "chat",
       "reasoning": {
-        "supported": false,
-        "default": false
+        "supported": true,
+        "default": true
       },
-      "tool_call": false,
-      "vision": false,
+      "tool_call": true,
+      "vision": true,
       "limit": {
-        "context": 16384,
-        "output": 8192
+        "context": 262144,
+        "output": 131072
       },
       "modalities": {
         "input": [
-          "text"
+          "text",
+          "image"
         ],
         "output": [
           "text"
@@ -10924,311 +11457,24 @@
       }
     },
     {
-      "id": "qwen3:235b",
-      "name": "qwen3 235b",
-      "display_name": "qwen3 235b",
+      "id": "qwen3.8-flash-next",
+      "name": "qwen3.8-flash-next",
+      "display_name": "qwen3.8-flash-next",
       "type": "chat",
       "reasoning": {
-        "supported": false,
-        "default": false
+        "supported": true,
+        "default": true
       },
-      "tool_call": false,
-      "vision": false,
+      "tool_call": true,
+      "vision": true,
       "limit": {
-        "context": 128000,
-        "output": 64000
+        "context": 262144,
+        "output": 131072
       },
       "modalities": {
         "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen3:30b",
-      "name": "qwen3 30b",
-      "display_name": "qwen3 30b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen3:32b",
-      "name": "qwen3 32b",
-      "display_name": "qwen3 32b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen3:4b",
-      "name": "qwen3 4b",
-      "display_name": "qwen3 4b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen3:8b",
-      "name": "qwen3 8b",
-      "display_name": "qwen3 8b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen:0.5b",
-      "name": "qwen 0.5b",
-      "display_name": "qwen 0.5b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen:1.8b",
-      "name": "qwen 1.8b",
-      "display_name": "qwen 1.8b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen:110b",
-      "name": "qwen 110b",
-      "display_name": "qwen 110b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen:14b",
-      "name": "qwen 14b",
-      "display_name": "qwen 14b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen:32b",
-      "name": "qwen 32b",
-      "display_name": "qwen 32b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen:4b",
-      "name": "qwen 4b",
-      "display_name": "qwen 4b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen:72b",
-      "name": "qwen 72b",
-      "display_name": "qwen 72b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "qwen:7b",
-      "name": "qwen 7b",
-      "display_name": "qwen 7b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 32768,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
+          "text",
+          "image"
         ],
         "output": [
           "text"
@@ -11788,6 +12034,54 @@
       }
     },
     {
+      "id": "smollm:135m",
+      "name": "smollm 135m",
+      "display_name": "smollm 135m",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "smollm:360m",
+      "name": "smollm 360m",
+      "display_name": "smollm 360m",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "smollm2",
       "name": "smollm2",
       "display_name": "smollm2",
@@ -11860,54 +12154,6 @@
       }
     },
     {
-      "id": "smollm:135m",
-      "name": "smollm 135m",
-      "display_name": "smollm 135m",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "smollm:360m",
-      "name": "smollm 360m",
-      "display_name": "smollm 360m",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
       "id": "snowflake-arctic-embed",
       "name": "snowflake-arctic-embed",
       "display_name": "snowflake-arctic-embed",
@@ -11921,54 +12167,6 @@
       "limit": {
         "context": 4096,
         "output": 2048
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "snowflake-arctic-embed2",
-      "name": "snowflake-arctic-embed2",
-      "display_name": "snowflake-arctic-embed2",
-      "type": "embedding",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 4096,
-        "output": 2048
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "snowflake-arctic-embed2:568m",
-      "name": "snowflake-arctic-embed2 568m",
-      "display_name": "snowflake-arctic-embed2 568m",
-      "type": "embedding",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
       },
       "modalities": {
         "input": [
@@ -12079,6 +12277,54 @@
       "id": "snowflake-arctic-embed:33m",
       "name": "snowflake-arctic-embed 33m",
       "display_name": "snowflake-arctic-embed 33m",
+      "type": "embedding",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "snowflake-arctic-embed2",
+      "name": "snowflake-arctic-embed2",
+      "display_name": "snowflake-arctic-embed2",
+      "type": "embedding",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 4096,
+        "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "snowflake-arctic-embed2:568m",
+      "name": "snowflake-arctic-embed2 568m",
+      "display_name": "snowflake-arctic-embed2 568m",
       "type": "embedding",
       "reasoning": {
         "supported": false,
@@ -12508,102 +12754,6 @@
       }
     },
     {
-      "id": "starcoder2",
-      "name": "starcoder2",
-      "display_name": "starcoder2",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": true,
-      "vision": false,
-      "limit": {
-        "context": 4096,
-        "output": 2048
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "starcoder2:15b",
-      "name": "starcoder2 15b",
-      "display_name": "starcoder2 15b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": true,
-      "vision": false,
-      "limit": {
-        "context": 16384,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "starcoder2:3b",
-      "name": "starcoder2 3b",
-      "display_name": "starcoder2 3b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": true,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "starcoder2:7b",
-      "name": "starcoder2 7b",
-      "display_name": "starcoder2 7b",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": true,
-      "vision": false,
-      "limit": {
-        "context": 8192,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
       "id": "starcoder:15b",
       "name": "starcoder 15b",
       "display_name": "starcoder 15b",
@@ -12679,6 +12829,102 @@
       "id": "starcoder:7b",
       "name": "starcoder 7b",
       "display_name": "starcoder 7b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": true,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "starcoder2",
+      "name": "starcoder2",
+      "display_name": "starcoder2",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": true,
+      "vision": false,
+      "limit": {
+        "context": 4096,
+        "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "starcoder2:15b",
+      "name": "starcoder2 15b",
+      "display_name": "starcoder2 15b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": true,
+      "vision": false,
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "starcoder2:3b",
+      "name": "starcoder2 3b",
+      "display_name": "starcoder2 3b",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": true,
+      "vision": false,
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "starcoder2:7b",
+      "name": "starcoder2 7b",
+      "display_name": "starcoder2 7b",
       "type": "chat",
       "reasoning": {
         "supported": false,
@@ -13396,6 +13642,30 @@
       }
     },
     {
+      "id": "wizardlm:7b-q2_K",
+      "name": "wizardlm 7b-q2_K",
+      "display_name": "wizardlm 7b-q2_K",
+      "type": "chat",
+      "reasoning": {
+        "supported": false,
+        "default": false
+      },
+      "tool_call": false,
+      "vision": false,
+      "limit": {
+        "context": 2048,
+        "output": 1024
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
       "id": "wizardlm2",
       "name": "wizardlm2",
       "display_name": "wizardlm2",
@@ -13433,30 +13703,6 @@
       "limit": {
         "context": 8192,
         "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "wizardlm:7b-q2_K",
-      "name": "wizardlm 7b-q2_K",
-      "display_name": "wizardlm 7b-q2_K",
-      "type": "chat",
-      "reasoning": {
-        "supported": false,
-        "default": false
-      },
-      "tool_call": false,
-      "vision": false,
-      "limit": {
-        "context": 2048,
-        "output": 1024
       },
       "modalities": {
         "input": [


### PR DESCRIPTION
## Summary
- Update `manual-templates/ollama.json` to match current [Ollama Library](https://ollama.com/library)
- Add 10 new model families: `glm-5.3`, `glm-5.3-flash`, `granite4.2`, `kimi-k3`, `laguna-s-2.1`, `muse-glimmer`, `nemotron-3.5-lightning`, `ornith-1.5`, `qwen3.8`, `qwen3.8-flash-next`
- Retain 7 families that are absent from the current index page but preserved per refresh guidance: `deepseek-v3.2`, `gemini-3-flash-preview`, `glm-4.7`, `glm-5`, `kimi-k2.5`, `minimax-m2.1`, `minimax-m2.5`
- Template model count: 577 → 587

## Verification
- `pnpm build` passes
- `node build/cli.js fetch-providers -p ollama -o dist` succeeds
- New IDs verified in `dist/ollama.json`

## Source
Inspired by `skills/ollama-template-refresh/SKILL.md` workflow.